### PR TITLE
Add half block trick to render bases at 2x zoom

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,14 +12,10 @@ use ratatui::{
 };
 
 use crate::error::TGVError;
-use crate::models::{
-    data::Data,
-    message::StateMessage,
-    mode::InputMode,
-};
+use crate::models::{data::Data, message::StateMessage, mode::InputMode};
 use crate::rendering::{
     render_alignment, render_console, render_coverage, render_error, render_help, render_sequence,
-    render_track,
+    render_sequence_at_2x, render_track,
 };
 use crate::settings::Settings;
 use crate::states::State;
@@ -155,6 +151,14 @@ impl Widget for &App {
                 match &self.data.sequence {
                     Some(sequence) => {
                         render_sequence(&sequence_area, buf, &viewing_region, sequence).unwrap();
+                    }
+                    None => {} // TODO: handle error
+                }
+            } else if viewing_window.zoom() == 2 {
+                match &self.data.sequence {
+                    Some(sequence) => {
+                        render_sequence_at_2x(&sequence_area, buf, &viewing_region, sequence)
+                            .unwrap();
                     }
                     None => {} // TODO: handle error
                 }

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -10,5 +10,5 @@ pub use console::render_console;
 pub use coverage::render_coverage;
 pub use error::render_error;
 pub use help::render_help;
-pub use sequence::render_sequence;
+pub use sequence::{render_sequence, render_sequence_at_2x};
 pub use track::render_track;

--- a/src/rendering/sequence.rs
+++ b/src/rendering/sequence.rs
@@ -1,17 +1,80 @@
 use crate::models::region::Region;
 use crate::models::sequence::Sequence;
-use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{palette::tailwind, Color, Style},
+};
 pub fn render_sequence(
     area: &Rect,
     buf: &mut Buffer,
     region: &Region,
     sequence: &Sequence,
 ) -> Result<(), ()> {
-    buf.set_string(
-        area.x,
-        area.y,
-        sequence.get_sequence(region).ok_or(())?,
-        Style::default(),
-    );
+    let sequence_string = sequence.get_sequence(region).ok_or(())?;
+
+    for i in 0..sequence_string.len() {
+        let base = sequence_string.chars().nth(i).unwrap();
+        let color = match base {
+            'A' | 'a' => BASE_A,
+            'C' | 'c' => BASE_C,
+            'G' | 'g' => BASE_G,
+            'T' | 't' => BASE_T,
+            _ => BASE_N,
+        };
+
+        buf.set_string(
+            area.x + i as u16,
+            area.y,
+            base.to_string(),
+            Style::default().bg(color),
+        );
+    }
+
+    Ok(())
+}
+
+const BASE_A: Color = tailwind::RED.c300;
+const BASE_C: Color = tailwind::GREEN.c300;
+const BASE_G: Color = tailwind::BLUE.c300;
+const BASE_T: Color = tailwind::YELLOW.c300;
+const BASE_N: Color = tailwind::GRAY.c300;
+
+pub fn render_sequence_at_2x(
+    area: &Rect,
+    buf: &mut Buffer,
+    region: &Region,
+    sequence: &Sequence,
+) -> Result<(), ()> {
+    let sequence_string = sequence.get_sequence(region).ok_or(())?;
+
+    for i in 0..sequence_string.len() / 2 {
+        let base_1 = sequence_string.chars().nth(i * 2).unwrap();
+        let base_2 = sequence_string.chars().nth(i * 2 + 1).unwrap();
+
+        let color_character = match base_1 {
+            'A' | 'a' => BASE_A,
+            'C' | 'c' => BASE_C,
+            'G' | 'g' => BASE_G,
+            'T' | 't' => BASE_T,
+            _ => BASE_N,
+        };
+
+        let color_background = match base_2 {
+            'A' | 'a' => BASE_A,
+            'C' | 'c' => BASE_C,
+            'G' | 'g' => BASE_G,
+            'T' | 't' => BASE_T,
+            _ => BASE_N,
+        };
+
+        buf.set_string(
+            area.x + i as u16,
+            area.y,
+            "▌".to_string(),
+            Style::default().fg(color_character).bg(color_background),
+        );
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Clever trick using the half-square character + foreground / background colors to render bases at half-character width  (see also: https://ratatui.rs/examples/style/colors_rgb/)