### PR TITLE
Distribute with docker - doesn't work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Binary and test files
+target
+test/output
+src/snapshots
+tests/
+
+# Demo files
+demo.mp4
+
+# MacOS
+.DS_Store
+
+# Python
+.venv
+
+# IDE
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:latest as builder
+WORKDIR /usr/src/app
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    perl-base \
+    libfindbin-libs-perl \
+    make \
+    clang \
+    libclang-dev
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm
+RUN apt-get update && apt-get install -y libssl3 ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/app/target/release/tgv /usr/local/bin/
+ENTRYPOINT ["tgv"] 


### PR DESCRIPTION
The build succeeds, but ratatui panics when attempting to run tgv in docker. 

I can't find an example ratatui project with a Dockerfile. It's probably not a good idea anyway - why run a tui inside from a docker?