### PR TITLE
Polish default locations for different reference genomes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ mod tests {
     #[case(None, None)]
     #[case(None, Some("-r TP53"))]
     #[case(None, Some("-r TP53 -g hg19"))]
+    #[case(None, Some("-g mm39"))]
+    #[case(None, Some("-g wuhCor1"))]
     #[case(Some("ncbi.sorted.bam"), Some("-r 22:33121120 -g hg19"))]
     #[case(Some("ncbi.sorted.bam"), Some("-r chr22:33121120 --no-reference"))]
     #[case(Some("covid.sorted.bam"), Some("--no-reference"))]

--- a/src/models/services/track_service.rs
+++ b/src/models/services/track_service.rs
@@ -28,6 +28,12 @@ pub struct TrackCache {
     /// Gene name -> Option<Gene>.
     /// If the gene name is not found, the value is None.
     gene_by_name: HashMap<String, Option<Gene>>,
+
+    /// Prefered track name.
+    /// None: Not initialized.
+    /// Some(None): Queried but not found.
+    /// Some(Some(name)): Queried and found.
+    prefered_track_name: Option<Option<String>>,
 }
 
 impl Default for TrackCache {
@@ -41,6 +47,7 @@ impl TrackCache {
         Self {
             track_by_contig: HashMap::new(),
             gene_by_name: HashMap::new(),
+            prefered_track_name: None,
         }
     }
 
@@ -74,6 +81,14 @@ impl TrackCache {
             }
         }
         self.track_by_contig.insert(contig.full_name(), track);
+    }
+
+    pub fn get_prefered_track_name(&self) -> Option<Option<String>> {
+        self.prefered_track_name.clone()
+    }
+
+    pub fn set_prefered_track_name(&mut self, prefered_track_name: Option<String>) {
+        self.prefered_track_name = Some(prefered_track_name);
     }
 }
 

--- a/src/states.rs
+++ b/src/states.rs
@@ -961,6 +961,6 @@ impl State {
             data_messages.extend(self.handle_movement_message(state_message)?);
         }
 
-        return Ok(data_messages);
+        Ok(data_messages)
     }
 }

--- a/src/states.rs
+++ b/src/states.rs
@@ -905,7 +905,7 @@ impl State {
                         .track_service
                         .as_ref()
                         .ok_or(TGVError::StateError(
-                            "Track service not initialized for default region".to_string(),
+                            "Track service not initialized".to_string(),
                         ))?;
 
                 let first_contig = self.data.contigs.first()?;
@@ -934,7 +934,7 @@ impl State {
                     } // Gene not found. Handle later.
                 }
             }
-            // Handle UcscAccession and None similarly: Go to first contig:1
+            // UcscAccession or None: handle it later.
             _ => {
                 vec![]
             }
@@ -960,6 +960,7 @@ impl State {
         for state_message in translated_messages {
             data_messages.extend(self.handle_movement_message(state_message)?);
         }
+
         return Ok(data_messages);
     }
 }

--- a/src/states.rs
+++ b/src/states.rs
@@ -891,29 +891,75 @@ impl State {
 
 /// Looking for the default region
 impl State {
-    const DEFAULT_GENE: &str = "KRAS";
     async fn handle_goto_default_message(&mut self) -> Result<Vec<DataMessage>, TGVError> {
-        match (
-            self.settings.reference.as_ref(),
-            self.settings.bam_path.as_ref(),
-        ) {
-            (Some(_), Some(_)) | (None, Some(_)) => {
-                self.handle_movement_message(StateMessage::GotoContigCoordinate(
-                    self.data.contigs.first()?.full_name(),
+        let reference = self.settings.reference.as_ref();
+        let mut translated_messages: Vec<StateMessage> = match reference {
+            Some(Reference::Hg38) | Some(Reference::Hg19) => {
+                // 1. If Hg38 / Hg19: TP53
+                vec![StateMessage::GoToGene("TP53".to_string())]
+            }
+            Some(Reference::UcscGenome { .. }) => {
+                // Find the first gene on the first contig. If anything is not found, handle it later.
+                let track_service =
+                    self.data
+                        .track_service
+                        .as_ref()
+                        .ok_or(TGVError::StateError(
+                            "Track service not initialized for default region".to_string(),
+                        ))?;
+
+                let first_contig = self.data.contigs.first()?;
+
+                // Try to get the first gene in the first contig.
+                // We use query_k_genes_after starting from coordinate 0 with k=1.
+                match track_service
+                    .query_k_genes_after(
+                        reference.unwrap(),
+                        first_contig,
+                        0,
+                        1,
+                        &mut self.data.track_cache,
+                    )
+                    .await
+                {
+                    Ok(gene) => {
+                        // Found a gene, go to its start (using 1-based coordinates for Goto)
+                        vec![StateMessage::GotoContigCoordinate(
+                            gene.contig().full_name(),
+                            gene.start() + 1,
+                        )]
+                    }
+                    Err(_) => {
+                        vec![]
+                    } // Gene not found. Handle later.
+                }
+            }
+            // Handle UcscAccession and None similarly: Go to first contig:1
+            _ => {
+                vec![]
+            }
+        };
+
+        if translated_messages.is_empty() {
+            // If reaches here, go to the first contig:1
+            if let Ok(first_contig) = self.data.contigs.first() {
+                translated_messages.push(StateMessage::GotoContigCoordinate(
+                    first_contig.full_name(),
                     1,
-                ))
-            }
-            (Some(_), None) => {
-                self.handle_goto_feature_message(StateMessage::GoToGene(
-                    Self::DEFAULT_GENE.to_string(),
-                ))
-                .await
-            }
-            (None, None) => {
-                Err(TGVError::StateError(
-                    "Neither a reference nor a BAM file is provided. Cannot identify the default region.".to_string(),
-                ))
+                ));
             }
         }
+
+        if translated_messages.is_empty() {
+            return Err(TGVError::StateError(
+                "Failed to find a default initial region. Please provide a starting region with -r.".to_string(),
+            ));
+        }
+
+        let mut data_messages = Vec::new();
+        for state_message in translated_messages {
+            data_messages.extend(self.handle_movement_message(state_message)?);
+        }
+        return Ok(data_messages);
     }
 }

--- a/src/states.rs
+++ b/src/states.rs
@@ -957,8 +957,20 @@ impl State {
         }
 
         let mut data_messages = Vec::new();
-        for state_message in translated_messages {
-            data_messages.extend(self.handle_movement_message(state_message)?);
+        for state_message in translated_messages.iter() {
+            match state_message {
+                StateMessage::GotoContigCoordinate(contig, position) => {
+                    data_messages.extend(self.handle_movement_message(state_message.clone())?);
+                    // TODO: handle this shit properly.
+                }
+                StateMessage::GoToGene(gene_id) => {
+                    data_messages.extend(
+                        self.handle_goto_feature_message(state_message.clone())
+                            .await?,
+                    );
+                }
+                _ => {}
+            }
         }
 
         Ok(data_messages)


### PR DESCRIPTION
Find the default start location with different input genomes. Logic:

- If human: TP53
- If ucsc assembly: find the first contig and the first gene. If the gene is not found (e.g. the gene track for the reference doesn't exist), go to contig:1.
- Else (e.g. --no-reference), go to contig:1 (provided from the BAM file)

Some logics are very poorly handled right now. For example, an actual SQL error and gene track not existing are mixed up together.

Also, message handling is a complete mess.

Improve this with better software pattern design.