### PR TITLE
Add bound check of rendering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -79,13 +79,21 @@ impl App {
                 let _ = terminal.clear();
             }
 
-            self.state.area = terminal.get_frame().area();
-
             // Render
 
             terminal
                 .draw(|frame| {
-                    self.draw(frame);
+                    let buffer = frame.buffer_mut();
+                    self.state.area = buffer.area.clone();
+                    self.rendering_state
+                        .render(
+                            buffer,
+                            &self.state,
+                            &self.registers,
+                            &self.repository,
+                            &self.settings.palette,
+                        )
+                        .unwrap()
                 })
                 .unwrap();
 
@@ -130,11 +138,6 @@ impl App {
         Ok(())
     }
 
-    /// Draw the app
-    pub fn draw(&self, frame: &mut Frame) {
-        frame.render_widget(self, self.state.area);
-    }
-
     /// close connections
     pub async fn close(&mut self) -> Result<(), TGVError> {
         self.repository.close().await?;
@@ -143,17 +146,3 @@ impl App {
 }
 const MIN_AREA_WIDTH: u16 = 10;
 const MIN_AREA_HEIGHT: u16 = 6;
-impl Widget for &App {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        self.rendering_state
-            .render(
-                area,
-                buf,
-                &self.state,
-                &self.registers,
-                &self.repository,
-                &self.settings.palette,
-            )
-            .unwrap()
-    }
-}

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -80,7 +80,7 @@ impl RenderingState {
 
     pub fn render(
         &self,
-        area: Rect,
+
         buf: &mut Buffer,
         state: &State,
         registers: &Registers,
@@ -93,13 +93,13 @@ impl RenderingState {
                 // For now, fall back to existing layout
                 state
                     .layout
-                    .render_all(area, buf, state, registers, repository, pallete)?;
+                    .render_all(buf, state, registers, repository, pallete)?;
             }
             DisplayMode::Help => {
-                render_help(area, buf)?;
+                render_help(state.area, buf)?;
             }
             DisplayMode::ContigList => {
-                render_contig_list(area, buf, state, registers, pallete)?;
+                render_contig_list(state.area, buf, state, registers, pallete)?;
             }
         }
         Ok(())

--- a/src/rendering/status_bar.rs
+++ b/src/rendering/status_bar.rs
@@ -45,20 +45,20 @@ pub fn render_status_bar(area: &Rect, buf: &mut Buffer, state: &State) -> Result
             string,
             Style::default(),
         );
-    } else {
-        buf.set_string(
-            area.x + area.width.saturating_sub(x_coordinate_string.len() as u16),
-            area.y,
-            x_coordinate_string,
-            Style::default(),
-        );
+    } else if area.height > 1 {
+        // buf.set_string(
+        //     area.x + area.width.saturating_sub(x_coordinate_string.len() as u16),
+        //     area.y,
+        //     x_coordinate_string,
+        //     Style::default(),
+        // );
 
-        buf.set_string(
-            area.x + area.width.saturating_sub(y_coordinate_string.len() as u16),
-            area.y + 1,
-            y_coordinate_string,
-            Style::default(),
-        );
+        // buf.set_string(
+        //     area.x + area.width.saturating_sub(y_coordinate_string.len() as u16),
+        //     area.y + 1,
+        //     y_coordinate_string,
+        //     Style::default(),
+        // );
     }
 
     Ok(())


### PR DESCRIPTION
For reason I don't fully understand, rapid window re-sizing can create a scenario that `area` and `buffer` have different sizes. I tried to put them as close as possible but they still can be out of sync. 

Added a bound check to prevent rendering when the sub component area go out of bound. 

Fixes #43 