### PR TITLE
Save and display alignment option 

### DIFF
--- a/src/alignment/alignment.rs
+++ b/src/alignment/alignment.rs
@@ -1,12 +1,15 @@
-use crate::alignment::{
-    coverage::{calculate_basewise_coverage, BaseCoverage, DEFAULT_COVERAGE},
-    read::AlignedRead,
-};
 use crate::error::TGVError;
 use crate::message::{AlignmentFilter, AlignmentSort};
 use crate::region::Region;
 use crate::sequence::Sequence;
 use crate::window::ViewingWindow;
+use crate::{
+    alignment::{
+        coverage::{calculate_basewise_coverage, BaseCoverage, DEFAULT_COVERAGE},
+        read::AlignedRead,
+    },
+    message::AlignmentDisplayOption,
+};
 use ratatui::layout::Rect;
 use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 
@@ -35,9 +38,11 @@ pub struct Alignment {
 
     /// y -> read indexes at y location
     pub ys_index: Vec<Vec<usize>>,
+
+    /// Default ys
+    default_ys: Vec<usize>,
 }
 
-/// Data loading
 impl Alignment {
     /// Check if data in [left, right] is all loaded.
     /// 1-based, inclusive.
@@ -113,7 +118,8 @@ impl Alignment {
             coverage: BTreeMap::new(),
             data_complete_left_bound: region.start,
             data_complete_right_bound: region.end,
-            ys: ys,
+            ys: ys.clone(),
+            default_ys: ys,
             show_read: show_reads,
             ys_index: Vec::new(),
         };
@@ -138,6 +144,33 @@ impl Alignment {
         self.ys_index = ys_index;
 
         Ok(self)
+    }
+
+    pub fn apply_options(
+        &mut self,
+        options: &Vec<AlignmentDisplayOption>,
+        window: &ViewingWindow,
+        area: &Rect,
+        reference_sequence: Option<&Sequence>,
+    ) -> Result<&mut Self, TGVError> {
+        for option in options {
+            match option {
+                AlignmentDisplayOption::Filter(filter) => {
+                    self.filter(filter, window, area, reference_sequence)?;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// Reset alignment options
+    pub fn reset(&mut self, reference_sequence: Option<&Sequence>) -> Result<&mut Self, TGVError> {
+        self.ys = self.default_ys.clone();
+        self.show_read = vec![true; self.reads.len()];
+
+        self.build_y_index()?.build_coverage(reference_sequence)
     }
 
     pub fn build_coverage(
@@ -180,7 +213,7 @@ impl Alignment {
 
     pub fn filter(
         &mut self,
-        filter: AlignmentFilter,
+        filter: &AlignmentFilter,
         window: &ViewingWindow,
         area: &Rect,
         reference_sequence: Option<&Sequence>,

--- a/src/alignment/alignment.rs
+++ b/src/alignment/alignment.rs
@@ -149,14 +149,12 @@ impl Alignment {
     pub fn apply_options(
         &mut self,
         options: &Vec<AlignmentDisplayOption>,
-        window: &ViewingWindow,
-        area: &Rect,
         reference_sequence: Option<&Sequence>,
     ) -> Result<&mut Self, TGVError> {
         for option in options {
             match option {
                 AlignmentDisplayOption::Filter(filter) => {
-                    self.filter(filter, window, area, reference_sequence)?;
+                    self.filter(filter, reference_sequence)?;
                 }
                 _ => {}
             }
@@ -214,12 +212,10 @@ impl Alignment {
     pub fn filter(
         &mut self,
         filter: &AlignmentFilter,
-        window: &ViewingWindow,
-        area: &Rect,
         reference_sequence: Option<&Sequence>,
     ) -> Result<&mut Self, TGVError> {
         for (i, read) in self.reads.iter().enumerate() {
-            self.show_read[i] = read.passes_filter(&filter, window, area)
+            self.show_read[i] = read.passes_filter(&filter)
         }
 
         self.ys = stack_tracks_for_reads(&self.reads, &self.show_read)?;

--- a/src/alignment/read.rs
+++ b/src/alignment/read.rs
@@ -270,12 +270,7 @@ impl AlignedRead {
         return false;
     }
 
-    pub fn passes_filter(
-        &self,
-        filter: &AlignmentFilter,
-        window: &ViewingWindow,
-        area: &Rect,
-    ) -> bool {
+    pub fn passes_filter(&self, filter: &AlignmentFilter) -> bool {
         match filter {
             AlignmentFilter::Default => true,
             AlignmentFilter::Base(position, base) => {
@@ -285,17 +280,13 @@ impl AlignedRead {
                     false
                 }
             }
-            AlignmentFilter::BaseAtCurrentPosition(base) => {
-                if let Some(base_u8) = self.base_at(window.middle(area)) {
-                    *base as u8 == base_u8
-                } else {
-                    false
-                }
-            }
+
             AlignmentFilter::BaseSoftclip(position) => self.is_softclip_at(*position),
-            AlignmentFilter::BaseAtCurrentPositionSoftClip => {
-                self.is_softclip_at(window.middle(area))
-            }
+
+            // They should be not be passed here.
+            // They should be translated upstream.
+            AlignmentFilter::BaseAtCurrentPosition(_)
+            | AlignmentFilter::BaseAtCurrentPositionSoftClip => true,
 
             _ => true, // TODO
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
 use crate::{display_mode::DisplayMode, error::TGVError, region::Region, strand::Strand};
 
-use std::str::FromStr;
+use std::fmt;
 use strum::Display;
 
 /// State messages

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,8 @@
 use crate::{display_mode::DisplayMode, error::TGVError, region::Region, strand::Strand};
 
 use std::fmt;
+use std::string::ToString;
+use strum;
 use strum::Display;
 
 /// State messages
@@ -85,14 +87,16 @@ pub enum DataMessage {
     RequiresCytobands(usize),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Display)]
 pub enum AlignmentDisplayOption {
+    #[strum(to_string = "Filter: {0}")]
     Filter(AlignmentFilter),
 
+    #[strum(to_string = "Sort: {0}")]
     Sort(AlignmentSort),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Display)]
 pub enum AlignmentFilter {
     Default,
 
@@ -100,21 +104,27 @@ pub enum AlignmentFilter {
     False,
 
     /// Start in a range (1-based, both-inclusive)
+    #[strum(to_string = "Starts in [{0},{1}]")]
     StartsIn(usize, usize),
     /// Ends in a range (1-based, both-inclusive)
+    #[strum(to_string = "Ends in [{0},{1}]")]
     EndsIn(usize, usize),
     /// Overlaps a range (1-based, both-inclusive)
+    #[strum(to_string = "Overlaps [{0},{1}]")]
     Overlaps(usize, usize),
 
     /// Strand
+    #[strum(to_string = "Strand={0}")]
     Strand(Strand),
 
     /// Base at position (1-based) equal to the character
+    #[strum(to_string = "Base({0})={1}")]
     Base(usize, char),
 
     BaseAtCurrentPosition(char),
 
     /// Base at position (1-based is softclip)
+    #[strum(to_string = "Base({0})=SOFTCLIP")]
     BaseSoftclip(usize),
 
     BaseAtCurrentPositionSoftClip,
@@ -137,8 +147,13 @@ pub enum AlignmentFilter {
     /// Tag equal to the value
     Tag(String, String),
 
+    #[strum(to_string = "NOT({0})")]
     Not(Box<AlignmentFilter>),
+
+    #[strum(to_string = "{0} AND {1}")]
     And(Box<AlignmentFilter>, Box<AlignmentFilter>),
+
+    #[strum(to_string = "{0} OR {1}")]
     Or(Box<AlignmentFilter>, Box<AlignmentFilter>),
 }
 
@@ -180,7 +195,7 @@ impl AlignmentFilter {
 /// Reference: https://github.com/igvteam/igv/blob/main/src/main/java/org/broad/igv/sam/SortOption.java
 ///
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Display)]
 pub enum AlignmentSort {
     /// Default
     Default,
@@ -192,12 +207,14 @@ pub enum AlignmentSort {
     StrandAtCurrentBase,
 
     /// Stand of reads covering a location
+    #[strum(to_string = "Strand({0})")]
     StrandAt(usize),
 
     /// Base of reads at the current location
     BaseAtCurrentPosition,
 
     /// Stand of reads covering a location
+    #[strum(to_string = "Base({0})")]
     BaseAt(usize),
 
     /// MAPQ, reversed order
@@ -228,9 +245,11 @@ pub enum AlignmentSort {
     Tag,
 
     /// Sort by 0 first and then 1
+    #[strum(to_string = "{0}, {1}")]
     Then(Box<AlignmentSort>, Box<AlignmentSort>),
 
     /// Reverse ordering
+    #[strum(to_string = "{0} (DESC)")]
     Reverse(Box<AlignmentSort>),
 }
 

--- a/src/register/command.rs
+++ b/src/register/command.rs
@@ -124,6 +124,7 @@ impl CommandModeRegister {
         }
 
         if let Ok((_, true)) = restore_default_options(&self.input) {
+            // TODO: this results in resetting twice now.
             return Ok(vec![StateMessage::SetAlignmentChange(vec![])]);
         }
 

--- a/src/rendering/status_bar.rs
+++ b/src/rendering/status_bar.rs
@@ -1,5 +1,6 @@
 use crate::{error::TGVError, states::State};
 
+use itertools::Itertools;
 use ratatui::{buffer::Buffer, layout::Rect, style::Style};
 
 pub fn render_status_bar(area: &Rect, buf: &mut Buffer, state: &State) -> Result<(), TGVError> {
@@ -23,7 +24,7 @@ pub fn render_status_bar(area: &Rect, buf: &mut Buffer, state: &State) -> Result
     // X and y coordinates
 
     let x_coordinate_string = format!("{}: {}", state.contig_name()?, state.window.middle(area));
-    let y_coordinate_string = if let Some(depth) = state.alignment_depth() {
+    let mut y_coordinate_string = if let Some(depth) = state.alignment_depth() {
         if depth == 0 {
             "".to_string()
         } else {
@@ -35,7 +36,17 @@ pub fn render_status_bar(area: &Rect, buf: &mut Buffer, state: &State) -> Result
         "".to_string()
     };
 
-    // println!("{}{}", x_coordinate_string, y_coordinate_string);
+    // Alignment options
+
+    if state.alignment_options.len() > 0 {
+        let alignment_option_string = state
+            .alignment_options
+            .iter()
+            .map(|option| format!("{:?}", option))
+            .join(",");
+
+        y_coordinate_string = y_coordinate_string + " (" + &alignment_option_string + ")";
+    }
 
     if area.height == 1 {
         let string = x_coordinate_string + "  " + &y_coordinate_string;
@@ -46,19 +57,19 @@ pub fn render_status_bar(area: &Rect, buf: &mut Buffer, state: &State) -> Result
             Style::default(),
         );
     } else if area.height > 1 {
-        // buf.set_string(
-        //     area.x + area.width.saturating_sub(x_coordinate_string.len() as u16),
-        //     area.y,
-        //     x_coordinate_string,
-        //     Style::default(),
-        // );
+        buf.set_string(
+            area.x + area.width.saturating_sub(x_coordinate_string.len() as u16),
+            area.y,
+            x_coordinate_string,
+            Style::default(),
+        );
 
-        // buf.set_string(
-        //     area.x + area.width.saturating_sub(y_coordinate_string.len() as u16),
-        //     area.y + 1,
-        //     y_coordinate_string,
-        //     Style::default(),
-        // );
+        buf.set_string(
+            area.x + area.width.saturating_sub(y_coordinate_string.len() as u16),
+            area.y + 1,
+            y_coordinate_string,
+            Style::default(),
+        );
     }
 
     Ok(())

--- a/src/rendering/status_bar.rs
+++ b/src/rendering/status_bar.rs
@@ -42,7 +42,7 @@ pub fn render_status_bar(area: &Rect, buf: &mut Buffer, state: &State) -> Result
         let alignment_option_string = state
             .alignment_options
             .iter()
-            .map(|option| format!("{:?}", option))
+            .map(|option| format!("{}", option))
             .join(",");
 
         y_coordinate_string = y_coordinate_string + " (" + &alignment_option_string + ")";

--- a/src/states.rs
+++ b/src/states.rs
@@ -20,6 +20,7 @@ use crate::{
     track::Track,
     window::ViewingWindow,
 };
+use itertools::Itertools;
 use ratatui::layout::Rect;
 
 /// Holds states of the application.
@@ -41,6 +42,7 @@ pub struct State {
 
     /// Alignment segments.
     pub alignment: Option<Alignment>,
+    pub alignment_options: Vec<AlignmentDisplayOption>,
 
     /// Tracks.
     pub track: Option<Track<Gene>>,
@@ -51,7 +53,7 @@ pub struct State {
     pub sequence_cache: SequenceCache,
 
     // TODO: in the first implementation, refresh all data when the viewing window is near the boundary.
-    /// Contigs in the BAM header
+    /// Consensus contig header from BAM and reference genomes
     pub contig_header: ContigHeader,
 
     /// Display mode
@@ -80,6 +82,7 @@ impl State {
             messages: Vec::new(),
 
             alignment: None,
+            alignment_options: Vec::new(),
             track: None,
             track_cache,
             sequence: None,
@@ -97,18 +100,6 @@ impl State {
             start: self.window.left(),
             end: self.window.right(&self.area),
         }
-    }
-
-    /// Start coordinate of bases displayed on the screen.
-    /// 1-based, inclusive.
-    pub fn start(&self) -> usize {
-        self.window.left()
-    }
-
-    /// End coordinate of bases displayed on the screen.
-    /// 1-based, inclusive.
-    pub fn end(&self) -> usize {
-        self.window.right(&self.area)
     }
 
     /// Middle coordinate of bases displayed on the screen.
@@ -131,10 +122,6 @@ impl State {
 
     pub fn alignment_depth(&self) -> Option<usize> {
         self.alignment.as_ref().map(|alignment| alignment.depth())
-    }
-
-    pub fn add_error_message(&mut self, error: String) {
-        self.messages.push(error);
     }
 
     /// Maximum length of the contig.
@@ -347,20 +334,17 @@ impl StateHandler {
 
             StateMessage::SetAlignmentChange(options) => {
                 if let Some(alignment) = state.alignment.as_mut() {
-                    for option in options {
-                        match option {
-                            AlignmentDisplayOption::Filter(filter) => {
-                                alignment.filter(
-                                    filter,
-                                    &state.window,
-                                    &state.area,
-                                    state.sequence.as_ref(),
-                                )?;
-                            }
-                            _ => {}
-                        }
-                    }
+                    alignment.reset(state.sequence.as_ref())?;
+
+                    alignment.apply_options(
+                        &options,
+                        &state.window,
+                        &state.area,
+                        state.sequence.as_ref(),
+                    )?;
                 }
+
+                state.alignment_options = options
             }
             StateMessage::AddAlignmentChange(options) => {}
         }
@@ -941,8 +925,8 @@ impl StateHandler {
         match data_message {
             DataMessage::RequiresCompleteAlignments(region) => {
                 if !Self::has_complete_alignment(state, &region) {
-                    state.alignment = Some(
-                        repository
+                    state.alignment = Some({
+                        let mut alignment = repository
                             .alignment_repository
                             .as_ref()
                             .unwrap()
@@ -950,8 +934,20 @@ impl StateHandler {
                                 &region,
                                 state.sequence.as_ref(),
                                 &state.contig_header,
-                            )?,
-                    ); // TODO: unwrap is weird.
+                            )?;
+
+                        alignment.apply_options(
+                            &state.alignment_options,
+                            &state.window,
+                            &state.area,
+                            state.sequence.as_ref(),
+                        )?;
+
+                        alignment
+                    });
+
+                    // apply sorting and filtering
+
                     loaded_data = true;
                 }
             }

--- a/src/strand.rs
+++ b/src/strand.rs
@@ -1,8 +1,12 @@
+use strum::Display;
+
 use crate::error::TGVError;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum Strand {
+    #[strum[to_string = "+"]]
     Forward,
+    #[strum[to_string = "-"]]
     Reverse,
 }
 


### PR DESCRIPTION
Save alignment options to `State`. They are displayed at the status bar and automatically applied at alignment reloading. 

Added `CLEAR` / `DEFAULT` command the clear the alignment options.