### PR TITLE
Removed last references to --list and --list-more

### DIFF
--- a/crates/tgv/src/settings.rs
+++ b/crates/tgv/src/settings.rs
@@ -80,7 +80,7 @@ pub struct Cli {
     region: Option<String>,
 
     /// Reference genome.
-    /// TGV supports all UCSC assemblies and accessions. See `tgv --list` or `tgv --list-more`.
+    /// TGV supports all UCSC assemblies and accessions. See `tgv list` or `tgv list --more`.
     #[arg(short = 'g', long = "reference", default_value = Reference::HG38)]
     reference: String,
 


### PR DESCRIPTION
Part 2 of an earlier pull request which sought to remove references to the old usage of --list and --list-more.

I discovered one last reference that pops up on the command line when executing `tgv help`

Thanks!