### PR TITLE
Fix base modification visualization

### DIFF
--- a/crates/gv-core/src/alignment/read.rs
+++ b/crates/gv-core/src/alignment/read.rs
@@ -9,7 +9,7 @@ use noodles::sam::{
     alignment::{
         RecordBuf,
         record::{
-            Cigar as CigarTrait, Flags,
+            Flags,
             cigar::{Op, op::Kind},
             data::field::Tag,
         },
@@ -390,7 +390,7 @@ impl TryFrom<RecordBuf> for AlignedRead {
 }
 
 /// Parse base modification data from the MM and ML auxiliary tags of a SAM record.
-/// Returns an empty map if the record has no MM/ML tags or if parsing fails.
+/// Returns all mapped modifications in MM/ML order.
 fn extract_base_modifications(
     mm_string: String,
     ml_bytes: Option<Vec<u8>>,
@@ -409,74 +409,79 @@ fn extract_base_modifications(
     })?
     .into();
 
-    let n_modifications = base_modifications
-        .iter()
-        .map(|group| group.positions().len())
-        .sum();
+    let mut ml_bytes = ml_bytes.unwrap_or_default().into_iter();
 
-    let mut ml_bytes = ml_bytes.unwrap_or(vec![255; base_modifications.len()]);
+    let mut mapped_modifications = Vec::new();
 
-    // If probability values are missing (should not happen by SAM specification), pad probabilities with 255 so that no modificaitons are hidden
-    ml_bytes.resize(n_modifications, 255);
+    for group in &base_modifications {
+        for position in group.positions() {
+            for modification in group.modifications() {
+                let probability = ml_bytes.next().unwrap_or(255);
+                let Some(reference_position) = get_reference_position_from_seq_position(
+                    *position as u64,
+                    alignment_start,
+                    cigars,
+                ) else {
+                    continue;
+                };
 
-    Ok(base_modifications
-        .iter()
-        .filter_map(|group| {
-            // Explaination:
-            // Noodles' modification gorup can have multiple .modifications().
-            // For example,
-            // - C+m,...; -> modifications().len() == 1.
-            // - C+mh,...; -> modifications().len() == 2. (ambiguous modification)
-            // For now, we only take the first modification type.
-            group.modifications().get(0).map(|modification_type| {
-                group
-                    .positions()
-                    .iter()
-                    .map(|position| (*modification_type, *position))
-            })
-        })
-        .flatten()
-        .zip(ml_bytes)
-        .map(|(mod_pos, prob)| {
-            (
-                get_reference_postion_from_seq_position(mod_pos.1 as u64, alignment_start, cigars),
-                mod_pos.0,
-                prob,
-            )
-        })
-        .collect_vec())
-}
-
-fn get_reference_postion_from_seq_position(pos: u64, alignment_start: u64, cigars: &[Op]) -> u64 {
-    let mut query_cursor = 0u64;
-    let mut reference_cursor = alignment_start;
-
-    for op in cigars {
-        if pos <= query_cursor {
-            return reference_cursor;
-        }
-        match op.kind() {
-            Kind::SoftClip | Kind::Insertion => {
-                query_cursor += op.len() as u64;
-            }
-            Kind::HardClip | Kind::Pad => {}
-            Kind::Deletion | Kind::Skip => {
-                reference_cursor += op.len() as u64;
-            }
-            Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
-                let next_query_cursor = query_cursor + op.len() as u64;
-
-                if pos <= next_query_cursor {
-                    return pos - query_cursor + reference_cursor;
-                }
-                query_cursor = next_query_cursor;
-                reference_cursor += op.len() as u64;
+                mapped_modifications.push((reference_position, *modification, probability));
             }
         }
     }
 
-    // Should not happen
-    reference_cursor.saturating_sub(1)
+    Ok(mapped_modifications)
+}
+
+fn get_reference_position_from_seq_position(
+    pos: u64,
+    alignment_start: u64,
+    cigars: &[Op],
+) -> Option<u64> {
+    let mut query_cursor = 0u64;
+    let mut reference_cursor = alignment_start;
+
+    for (op_index, op) in cigars.iter().enumerate() {
+        let len = op.len() as u64;
+        match op.kind() {
+            Kind::SoftClip => {
+                let next_query_cursor = query_cursor + len;
+                if (query_cursor..next_query_cursor).contains(&pos) {
+                    let offset = pos - query_cursor;
+                    if op_index == 0 {
+                        return alignment_start
+                            .checked_sub(len)
+                            .map(|left_softclip_start| left_softclip_start + offset)
+                            .filter(|coordinate| *coordinate > 0);
+                    }
+                    return Some(reference_cursor + offset);
+                }
+                query_cursor = next_query_cursor;
+            }
+            Kind::Insertion => {
+                let next_query_cursor = query_cursor + len;
+                if (query_cursor..next_query_cursor).contains(&pos) {
+                    return None;
+                }
+                query_cursor = next_query_cursor;
+            }
+            Kind::HardClip | Kind::Pad => {}
+            Kind::Deletion | Kind::Skip => {
+                reference_cursor += len;
+            }
+            Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                let next_query_cursor = query_cursor + len;
+
+                if (query_cursor..next_query_cursor).contains(&pos) {
+                    return Some(pos - query_cursor + reference_cursor);
+                }
+                query_cursor = next_query_cursor;
+                reference_cursor += len;
+            }
+        }
+    }
+
+    None
 }
 
 /// See: https://samtools.github.io/hts-specs/SAMv1.pdf
@@ -694,11 +699,20 @@ pub fn calculate_rendering_contexts(
         })
     }
 
+    const LEGACY_BASE_MODIFICATION_TAG: Tag = Tag::new(b'M', b'm');
+    const LEGACY_BASE_MODIFICATION_PROBABILITY_TAG: Tag = Tag::new(b'M', b'l');
+
     // Fetch MM tag (string, type Z).
-    if let Some(Value::String(s)) = data.get(&Tag::BASE_MODIFICATIONS) {
+    if let Some(Value::String(s)) = data
+        .get(&Tag::BASE_MODIFICATIONS)
+        .or_else(|| data.get(&LEGACY_BASE_MODIFICATION_TAG))
+    {
         let ml_string = String::from_utf8_lossy(s.as_ref()).into_owned();
 
-        let ml_bytes = match data.get(&Tag::BASE_MODIFICATION_PROBABILITIES) {
+        let ml_bytes = match data
+            .get(&Tag::BASE_MODIFICATION_PROBABILITIES)
+            .or_else(|| data.get(&LEGACY_BASE_MODIFICATION_PROBABILITY_TAG))
+        {
             Some(Value::Array(Array::UInt8(values))) => Some(values.clone()),
             _ => None,
         };
@@ -1070,18 +1084,148 @@ impl ReadPair {
 mod tests {
 
     use super::*;
-    // use noodles::bam::record::{Cigar, CigarString};
-    use noodles::bam;
     use noodles::sam::{
         self,
-        alignment::{
-            io::Write,
-            record::cigar::{Op, op::Kind},
-        },
+        alignment::record::cigar::{Op, op::Kind},
+        record::data::field::value::base_modifications::group::modification,
     };
-    use std::io;
 
     use rstest::rstest;
+
+    #[test]
+    fn extract_base_modifications_defaults_missing_probabilities_for_each_position() {
+        let cigars = vec![Op::new(Kind::Match, 3)];
+        let sequence = sam::alignment::record_buf::Sequence::from(b"CCC");
+
+        let modifications = extract_base_modifications(
+            "C+m,0,0,0;".to_string(),
+            None,
+            &Flags::default(),
+            &sequence,
+            &cigars,
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(
+            modifications,
+            vec![
+                (10, modification::FIVE_METHYLCYTOSINE, 255),
+                (11, modification::FIVE_METHYLCYTOSINE, 255),
+                (12, modification::FIVE_METHYLCYTOSINE, 255),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_base_modifications_consumes_probability_for_each_position_and_modification() {
+        let cigars = vec![Op::new(Kind::Match, 2)];
+        let sequence = sam::alignment::record_buf::Sequence::from(b"CC");
+
+        let modifications = extract_base_modifications(
+            "C+mh,0,0;".to_string(),
+            Some(vec![10, 200, 180, 20]),
+            &Flags::default(),
+            &sequence,
+            &cigars,
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(
+            modifications,
+            vec![
+                (10, modification::FIVE_METHYLCYTOSINE, 10),
+                (10, modification::FIVE_HYDROXYMETHYLCYTOSINE, 200),
+                (11, modification::FIVE_METHYLCYTOSINE, 180),
+                (11, modification::FIVE_HYDROXYMETHYLCYTOSINE, 20),
+            ]
+        );
+    }
+
+    #[test]
+    fn get_reference_position_from_seq_position_handles_cigar_boundaries() {
+        let cigars = vec![
+            Op::new(Kind::SoftClip, 2),
+            Op::new(Kind::Match, 2),
+            Op::new(Kind::Insertion, 1),
+            Op::new(Kind::Match, 2),
+            Op::new(Kind::SoftClip, 1),
+        ];
+
+        assert_eq!(
+            get_reference_position_from_seq_position(0, 10, &cigars),
+            Some(8)
+        );
+        assert_eq!(
+            get_reference_position_from_seq_position(2, 10, &cigars),
+            Some(10)
+        );
+        assert_eq!(
+            get_reference_position_from_seq_position(4, 10, &cigars),
+            None
+        );
+        assert_eq!(
+            get_reference_position_from_seq_position(5, 10, &cigars),
+            Some(12)
+        );
+        assert_eq!(
+            get_reference_position_from_seq_position(7, 10, &cigars),
+            Some(14)
+        );
+    }
+
+    #[test]
+    fn calculate_rendering_contexts_adds_base_modification_modifiers() {
+        let cigars = vec![Op::new(Kind::Match, 3)];
+        let mut data = Data::default();
+        data.insert(Tag::new(b'M', b'm'), Value::from("C+m,0,0,0;"));
+        data.insert(Tag::new(b'M', b'l'), Value::from(vec![255u8, 80, 20]));
+
+        let record_buf = sam::alignment::RecordBuf::builder()
+            .set_sequence(sam::alignment::record_buf::Sequence::from(b"CCC"))
+            .set_data(data)
+            .build();
+
+        let mut contexts = Vec::new();
+        calculate_rendering_contexts(
+            &mut contexts,
+            10,
+            &record_buf.flags(),
+            &cigars,
+            record_buf.sequence(),
+            record_buf.data(),
+            &Sequence::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            contexts,
+            vec![RenderingContext {
+                start: 10,
+                end: 12,
+                kind: RenderingContextKind::Match,
+                modifiers: vec![
+                    RenderingContextModifier::Forward,
+                    RenderingContextModifier::BaseModification(
+                        10,
+                        modification::FIVE_METHYLCYTOSINE,
+                        255
+                    ),
+                    RenderingContextModifier::BaseModification(
+                        11,
+                        modification::FIVE_METHYLCYTOSINE,
+                        80
+                    ),
+                    RenderingContextModifier::BaseModification(
+                        12,
+                        modification::FIVE_METHYLCYTOSINE,
+                        20
+                    ),
+                ],
+            }]
+        );
+    }
 
     #[rstest]
     #[case(10, vec![(Kind::Match, 3)],  b"ATT", false,Sequence::default(), vec![RenderingContext{
@@ -1261,8 +1405,6 @@ mod tests {
         if is_reverse {
             flags = flags.union(Flags::from(0x10));
         }
-
-        let header = sam::Header::default();
 
         let record_buf = sam::alignment::RecordBuf::builder()
             .set_sequence(sam::alignment::record_buf::Sequence::from(seq))

--- a/crates/gv-core/src/alignment/read.rs
+++ b/crates/gv-core/src/alignment/read.rs
@@ -155,15 +155,16 @@ impl AlignedRead {
             .mapping_quality()
             .map(|quality| quality.get().to_string())
             .unwrap_or_else(|| ".".to_string());
+        let flags = u16::from(self.record.flags());
+        let cigar = cigar_to_string(self.record.cigar())?;
 
         Ok(format!(
-            "{}  Flags={:?}  Start={}  MAPQ={}  Cigar={:?}",
+            "{}  Flags={}  MAPQ={}  Cigar={}",
             //String::from_utf8_lossy(&self.record.sequence()[..]),
             read_name,
-            self.record.flags(),
-            self.start,
+            flags,
             mapping_quality,
-            self.record.cigar()
+            cigar
         ))
     }
 
@@ -350,6 +351,12 @@ impl AlignedRead {
     //     Self::from_bam_record(read_index, record, reference_sequence)
     // }
     //
+}
+
+fn cigar_to_string(cigar: &sam::alignment::record_buf::Cigar) -> Result<String, TGVError> {
+    let mut buf = Vec::new();
+    sam::io::writer::record::write_cigar(&mut buf, cigar)?;
+    Ok(String::from_utf8(buf)?)
 }
 
 impl TryFrom<RecordBuf> for AlignedRead {
@@ -1086,11 +1093,38 @@ mod tests {
     use super::*;
     use noodles::sam::{
         self,
-        alignment::record::cigar::{Op, op::Kind},
+        alignment::{
+            record::{
+                MappingQuality,
+                cigar::{Op, op::Kind},
+            },
+            record_buf::Cigar,
+        },
         record::data::field::value::base_modifications::group::modification,
     };
 
     use rstest::rstest;
+
+    #[test]
+    fn describe_shows_sam_style_flags_and_cigar_without_start() -> Result<(), TGVError> {
+        let cigar: Cigar = [Op::new(Kind::Match, 4), Op::new(Kind::SoftClip, 2)]
+            .into_iter()
+            .collect();
+
+        let record = sam::alignment::RecordBuf::builder()
+            .set_name("r0")
+            .set_flags(Flags::from(80))
+            .set_alignment_start(noodles::core::Position::try_from(3).unwrap())
+            .set_mapping_quality(MappingQuality::new(60).unwrap())
+            .set_cigar(cigar)
+            .build();
+
+        let read = AlignedRead::try_from(record)?;
+
+        assert_eq!(read.describe()?, "r0  Flags=80  MAPQ=60  Cigar=4M2S");
+
+        Ok(())
+    }
 
     #[test]
     fn extract_base_modifications_defaults_missing_probabilities_for_each_position() {

--- a/crates/gv-core/src/alignment/read.rs
+++ b/crates/gv-core/src/alignment/read.rs
@@ -411,7 +411,7 @@ fn extract_base_modifications(
 
     let n_modifications = base_modifications
         .iter()
-        .map(|group| group.modifications().len())
+        .map(|group| group.positions().len())
         .sum();
 
     let mut ml_bytes = ml_bytes.unwrap_or(vec![255; base_modifications.len()]);
@@ -421,12 +421,26 @@ fn extract_base_modifications(
 
     Ok(base_modifications
         .iter()
-        .flat_map(|group| group.modifications().iter().zip(group.positions().iter()))
+        .filter_map(|group| {
+            // Explaination:
+            // Noodles' modification gorup can have multiple .modifications().
+            // For example,
+            // - C+m,...; -> modifications().len() == 1.
+            // - C+mh,...; -> modifications().len() == 2. (ambiguous modification)
+            // For now, we only take the first modification type.
+            group.modifications().get(0).map(|modification_type| {
+                group
+                    .positions()
+                    .iter()
+                    .map(|position| (*modification_type, *position))
+            })
+        })
+        .flatten()
         .zip(ml_bytes)
         .map(|(mod_pos, prob)| {
             (
-                get_reference_postion_from_seq_position(*mod_pos.1 as u64, alignment_start, cigars),
-                *mod_pos.0,
+                get_reference_postion_from_seq_position(mod_pos.1 as u64, alignment_start, cigars),
+                mod_pos.0,
                 prob,
             )
         })
@@ -693,7 +707,7 @@ pub fn calculate_rendering_contexts(
 
         for (pos, modification, prob) in base_modification_modifiers.into_iter() {
             for context in rendering_context.iter_mut() {
-                if (context.start..context.end).contains(&pos) {
+                if (context.start..=context.end).contains(&pos) {
                     context
                         .modifiers
                         .push(RenderingContextModifier::BaseModification(

--- a/crates/tgv/src/main.rs
+++ b/crates/tgv/src/main.rs
@@ -17,10 +17,8 @@ use tgv::{
 async fn main() -> Result<(), TGVError> {
     let cli = Cli::parse();
     let log_path = default_log_file_path();
-    let log_level = if cli.trace_enabled() {
+    let log_level = if cli.debug_enabled() {
         log::LevelFilter::Trace
-    } else if cli.debug_enabled() {
-        log::LevelFilter::Debug
     } else {
         log::LevelFilter::Info
     };

--- a/crates/tgv/src/rendering/alignment.rs
+++ b/crates/tgv/src/rendering/alignment.rs
@@ -15,6 +15,7 @@ use ratatui::{
     layout::{Position, Rect},
     style::Style,
 };
+use std::collections::HashMap;
 
 /// Render an alignment on the alignment area.
 pub fn render_alignment(
@@ -169,6 +170,23 @@ fn render_contexts(
         ),
     }
 
+    let mut best_base_modifications = HashMap::new();
+    for modifier in &context.modifiers {
+        if let RenderingContextModifier::BaseModification(coordinate, modification, probability) =
+            modifier
+        {
+            best_base_modifications
+                .entry(*coordinate)
+                .and_modify(|(best_modification, best_probability)| {
+                    if *probability > *best_probability {
+                        *best_modification = *modification;
+                        *best_probability = *probability;
+                    }
+                })
+                .or_insert((*modification, *probability));
+        }
+    }
+
     // ── Modifiers ─────────────────────────────────────────────────────────
     for modifier in context.modifiers.iter() {
         match modifier {
@@ -221,14 +239,19 @@ fn render_contexts(
                 }
             }
 
-            RenderingContextModifier::BaseModification(coordinate, modification, probability) => {
+            RenderingContextModifier::BaseModification(coordinate, _, _) => {
+                let Some((modification, probability)) = best_base_modifications.remove(coordinate)
+                else {
+                    continue;
+                };
+
                 if let OnScreenCoordinate::OnScreen(x) =
                     alignment_view.onscreen_x_coordinate(*coordinate, area)
                     && let Some(cell) =
                         buf.cell_mut(Position::new(area.x + x as u16, area.y + onscreen_y))
                 {
                     cell.set_style(
-                        Style::default().bg(pallete.modification_color(modification, *probability)),
+                        Style::default().bg(pallete.modification_color(&modification, probability)),
                     );
                 }
             }

--- a/crates/tgv/src/rendering/colors.rs
+++ b/crates/tgv/src/rendering/colors.rs
@@ -1,7 +1,9 @@
 use gv_core::cytoband::Stain;
 use ratatui::style::{Color, palette::tailwind};
 
-use noodles::sam::record::data::field::value::base_modifications::group::*;
+use noodles::sam::record::data::field::value::base_modifications::group::{
+    Modification, modification,
+};
 // Background
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[allow(non_snake_case)]
@@ -125,8 +127,8 @@ impl Palette {
     /// probability (0-255 from the ML tag, where 255 = fully modified).
     pub fn modification_color(&self, modification: &Modification, probability: u8) -> Color {
         // FIXME: colors for other modifications
-        match modification {
-            _FIVE_METHYLCYTOSINE => {
+        match *modification {
+            modification::FIVE_METHYLCYTOSINE => {
                 if probability >= 179 {
                     self.MOD_5MC_HIGH
                 } else if probability >= 77 {
@@ -135,8 +137,8 @@ impl Palette {
                     self.MOD_5MC_LOW
                 }
             }
-            _FIVE_HYDROXYMETHYLCYTOSINE => self.MOD_5HMC,
-            _SIX_METHYLADENINE => self.MOD_6MA,
+            modification::FIVE_HYDROXYMETHYLCYTOSINE => self.MOD_5HMC,
+            modification::SIX_METHYLADENINE => self.MOD_6MA,
             _ => self.MOD_5MC_MED,
         }
     }

--- a/crates/tgv/src/rendering/coverage.rs
+++ b/crates/tgv/src/rendering/coverage.rs
@@ -30,12 +30,18 @@ pub fn render_coverage(
         return Ok(());
     }
 
-    let mut binned_coverage = calculate_binned_coverage(
-        alignment,
-        alignment_view.left(area),
-        alignment_view.right(area),
-        area.width as usize,
-    )?;
+    let plot_area = if area.height > MIN_AREA_HEIGHT {
+        Rect::new(area.x, area.y + 1, area.width, area.height - 1)
+    } else {
+        *area
+    };
+
+    let Some((left, right)) = displayed_coverage_bounds(alignment_view, &plot_area) else {
+        return Ok(());
+    };
+
+    let mut binned_coverage =
+        calculate_binned_coverage(alignment, left, right, plot_area.width as usize)?;
 
     let y_max: usize = round_up_max_coverage(
         (0..binned_coverage[0].len())
@@ -47,11 +53,21 @@ pub fn render_coverage(
         .add_data(binned_coverage.remove(0), palette.COVERAGE_ALT)
         .add_data(binned_coverage.remove(0), palette.COVERAGE_TOTAL)
         .max(y_max)
-        .render(*area, buf);
+        .render(plot_area, buf);
 
-    buf.set_string(area.x, area.y, format!("[0-{}]", y_max,), Style::default());
+    if area.height > MIN_AREA_HEIGHT {
+        buf.set_string(area.x, area.y, format!("[0-{}]", y_max,), Style::default());
+    }
 
     Ok(())
+}
+
+fn displayed_coverage_bounds(alignment_view: &AlignmentView, area: &Rect) -> Option<(u64, u64)> {
+    let (left, _) = alignment_view.coordinates_of_onscreen_x(area.left(), area)?;
+    let (_, right) =
+        alignment_view.coordinates_of_onscreen_x(area.right().checked_sub(1)?, area)?;
+
+    Some((left, right))
 }
 
 /// Round up the maximum coverage to two significant digits.
@@ -80,17 +96,18 @@ fn round_up_max_coverage(x: usize) -> usize {
 
 /// Get a linear space of n_bins between left and right.
 /// 1-based, inclusive.
-/// Returns a vector of n_bins + 1 elements.
+/// Returns a vector of n_bins elements.
 fn get_linear_space(left: u64, right: u64, n_bins: usize) -> Result<Vec<(u64, u64)>, TGVError> {
     if n_bins == 0 {
         return Err(TGVError::ValueError("n_bins is 0".to_string()));
     }
 
-    if right <= left {
+    if right < left {
         return Err(TGVError::ValueError("Right is less than left".to_string()));
     }
 
-    if n_bins as u64 > right - left {
+    let length = right - left + 1;
+    if n_bins as u64 > length {
         // FIXME: make this permissive? Don't wanna crash the app because of a rendering problem.
         // Could happen if the region is weird.
         return Err(TGVError::ValueError(format!(
@@ -99,22 +116,14 @@ fn get_linear_space(left: u64, right: u64, n_bins: usize) -> Result<Vec<(u64, u6
         )));
     }
 
-    let mut bins: Vec<(u64, u64)> = Vec::new();
-    let mut pivot = left as f64; // f32 here actually causes problem for genome coordinates
+    Ok((0..n_bins)
+        .map(|i| {
+            let bin_left = left + i as u64 * length / n_bins as u64;
+            let bin_right = left + (i as u64 + 1) * length / n_bins as u64 - 1;
 
-    let bin_width: f64 = (right - left) as f64 / n_bins as f64;
-
-    for i in 0..n_bins {
-        let bin_left = if i == 0 { left } else { pivot as u64 + 1 };
-
-        pivot += bin_width;
-
-        let bin_right = if i == n_bins - 1 { right } else { pivot as u64 };
-
-        bins.push((bin_left, bin_right));
-    }
-
-    Ok(bins)
+            (bin_left, bin_right)
+        })
+        .collect())
 }
 
 /// Calculate the binned coverage in [left_bound, right_bound].
@@ -366,10 +375,10 @@ mod tests {
 
     #[rstest]
     #[case(1, 5, 0, Err(TGVError::ValueError("n_bins is 0".to_string())))]
-    #[case(1, 5, 5, Err(TGVError::ValueError("n_bins is greater than the number of bases in the region".to_string())))]
-    #[case(5,5, 1, Err(TGVError::ValueError("n_bins is greater than the number of bases in the region".to_string())))]
+    #[case(1, 5, 5, Ok(vec![(1,1), (2,2), (3,3), (4,4), (5,5)]))]
+    #[case(5,5, 1, Ok(vec![(5,5)]))]
     #[case(5, 4, 1, Err(TGVError::ValueError("Right is less than left".to_string())))]
-    #[case(25398019, 25398025, 3, Ok(vec![(25398019, 25398021), (25398022, 25398023), (25398024, 25398025)]))] // large interger matters here. Using f32 in the function causes problem for large integers.
+    #[case(25398019, 25398025, 3, Ok(vec![(25398019, 25398020), (25398021, 25398022), (25398023, 25398025)]))]
     #[case(5,10, 1, Ok(vec![(5,10)]))]
     #[case(5, 10, 2, Ok(vec![(5,7), (8,10)]))]
     fn test_get_linear_space_specific_cases(
@@ -381,7 +390,7 @@ mod tests {
         let result = get_linear_space(left, right, n_bins);
         match (result, expected) {
             (Ok(result), Ok(expected)) => assert_eq!(result, expected),
-            (Err(e), Err(expected)) => {} // OK
+            (Err(_e), Err(_expected)) => {}
             _ => panic!("Unexpected test result"),
         }
     }

--- a/crates/tgv/src/rendering/help.rs
+++ b/crates/tgv/src/rendering/help.rs
@@ -42,7 +42,6 @@ pub fn render_help(area: &Rect, buf: &mut Buffer) -> Result<(), TGVError> {
  |:_gene_|         Go to _gene_                         Example: :KRAS
  |filter base(_pos_) = _base_|   Filter by base         Example: :filter base(123)=A
  |:paired|                       View reads as pairs
- |:mod|                          Color bases by 5mC/5hmC modification probability (MM/ML tags)
  |:clear|                        Reset alignment display options
  ",
         env!("CARGO_PKG_VERSION")

--- a/crates/tgv/src/settings.rs
+++ b/crates/tgv/src/settings.rs
@@ -90,13 +90,9 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     online: bool,
 
-    /// [For development only] Display messages in the terminal.
+    /// [For development only] Save all log information in the log file.
     #[arg(long)]
     debug: bool,
-
-    /// [For development only] Save trace logs in the log file.
-    #[arg(long)]
-    trace: bool,
 
     /// Choose the UCSC host. Defaults to auto when not specified.
     #[arg(long, value_enum)]
@@ -117,11 +113,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn debug_enabled(&self) -> bool {
-        self.debug || self.trace
-    }
-
-    pub fn trace_enabled(&self) -> bool {
-        self.trace
+        self.debug
     }
 
     pub fn initial_movement(&self) -> Result<Vec<Message>, TGVError> {
@@ -488,7 +480,7 @@ mod tests {
         ..gv_core::settings::Settings::default()},
         ..Settings::default()
     }))]
-    #[case("tgv input.bam --trace", Ok(Settings {
+    #[case("tgv input.bam --debug", Ok(Settings {
         core: gv_core::settings::Settings {
         file_paths: vec![FilePath::AlignmentPath(bam("input.bam"))],
         ..gv_core::settings::Settings::default()},


### PR DESCRIPTION

<img width="870" height="625" alt="image" src="https://github.com/user-attachments/assets/43715c65-e9f9-4c6c-9f62-b707dab9cc3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved alignment base-modification visualization to show the highest-confidence modification per reference coordinate.
  * Updated alignment read description to render CIGAR and flag details more consistently.

* **Bug Fixes**
  * More robust base-modification parsing, including correct handling of missing probabilities and proper mapping across CIGAR boundaries.

* **Documentation**
  * Removed an outdated help-screen command entry for base-modification probability coloring.

* **Chores**
  * Simplified logging and CLI tracing options: trace support was removed in favor of debug-only logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->