### PR TITLE
Handle empty read sequences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ For doctests, use `cargo test --doc` (doctests are not supported by nextest).
 
 ### Test organization
 
+- Do not add new tests unless the user explicitly asks for them. If tests seem especially beneficial, ask for confirmation before adding them.
 - Unit tests in the same file as the code they test.
 - Use `#[rstest]` and `#[case(...)]` parameterized tests when possible, especially for related scenarios that share the same setup and assertions.
 - Do not add unit tests for rendering code unless explicitly asked.

--- a/crates/gv-core/src/alignment/coverage.rs
+++ b/crates/gv-core/src/alignment/coverage.rs
@@ -15,7 +15,7 @@ pub fn calculate_basewise_coverage(
     reference_sequence: &Sequence,
 ) -> Result<HashMap<u64, BaseCoverage>, TGVError> {
     let mut output: HashMap<u64, BaseCoverage> = HashMap::new();
-    if cigar.as_ref().is_empty() {
+    if cigar.as_ref().is_empty() || sequence.is_empty() {
         return Ok(output);
     }
 
@@ -209,3 +209,22 @@ pub static DEFAULT_COVERAGE: BaseCoverage = BaseCoverage {
     softclip: 0,
     reference_base: b'N',
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles::sam::alignment::record::cigar::{Op, op::Kind};
+
+    #[test]
+    fn calculate_basewise_coverage_ignores_empty_sequence() -> Result<(), TGVError> {
+        let cigar = [Op::new(Kind::Match, 1)].into_iter().collect();
+        let sequence = sam::alignment::record_buf::Sequence::default();
+        let reference_sequence = Sequence::default();
+
+        let coverage = calculate_basewise_coverage(1, &cigar, &sequence, &reference_sequence)?;
+
+        assert!(coverage.is_empty());
+
+        Ok(())
+    }
+}

--- a/crates/gv-core/src/alignment/coverage.rs
+++ b/crates/gv-core/src/alignment/coverage.rs
@@ -209,22 +209,3 @@ pub static DEFAULT_COVERAGE: BaseCoverage = BaseCoverage {
     softclip: 0,
     reference_base: b'N',
 };
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use noodles::sam::alignment::record::cigar::{Op, op::Kind};
-
-    #[test]
-    fn calculate_basewise_coverage_ignores_empty_sequence() -> Result<(), TGVError> {
-        let cigar = [Op::new(Kind::Match, 1)].into_iter().collect();
-        let sequence = sam::alignment::record_buf::Sequence::default();
-        let reference_sequence = Sequence::default();
-
-        let coverage = calculate_basewise_coverage(1, &cigar, &sequence, &reference_sequence)?;
-
-        assert!(coverage.is_empty());
-
-        Ok(())
-    }
-}

--- a/crates/gv-core/src/alignment/read.rs
+++ b/crates/gv-core/src/alignment/read.rs
@@ -1269,25 +1269,4 @@ mod tests {
 
         assert_eq!(contexts, expected_rendering_contexts)
     }
-
-    #[test]
-    fn calculate_rendering_contexts_ignores_empty_sequence() -> Result<(), TGVError> {
-        let cigars = vec![Op::new(Kind::Match, 1)];
-        let record_buf = sam::alignment::RecordBuf::builder().build();
-        let mut contexts = Vec::new();
-
-        calculate_rendering_contexts(
-            &mut contexts,
-            1,
-            &record_buf.flags(),
-            &cigars,
-            &record_buf.sequence(),
-            &record_buf.data(),
-            &Sequence::default(),
-        )?;
-
-        assert!(contexts.is_empty());
-
-        Ok(())
-    }
 }

--- a/crates/gv-core/src/alignment/read.rs
+++ b/crates/gv-core/src/alignment/read.rs
@@ -476,7 +476,7 @@ pub fn calculate_rendering_contexts(
     reference_sequence: &Sequence,
 ) -> Result<(), TGVError> {
     rendering_context.clear();
-    if cigars.is_empty() {
+    if cigars.is_empty() || seq.is_empty() {
         return Ok(());
     }
 
@@ -1268,5 +1268,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(contexts, expected_rendering_contexts)
+    }
+
+    #[test]
+    fn calculate_rendering_contexts_ignores_empty_sequence() -> Result<(), TGVError> {
+        let cigars = vec![Op::new(Kind::Match, 1)];
+        let record_buf = sam::alignment::RecordBuf::builder().build();
+        let mut contexts = Vec::new();
+
+        calculate_rendering_contexts(
+            &mut contexts,
+            1,
+            &record_buf.flags(),
+            &cigars,
+            &record_buf.sequence(),
+            &record_buf.data(),
+            &Sequence::default(),
+        )?;
+
+        assert!(contexts.is_empty());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes #85

- Return early from basewise coverage calculation when the read sequence is empty.
- Return early from rendering-context calculation when the read sequence is empty.
- Add regression coverage for both paths.
