### PR TITLE
Add HTTPS fallback for UCSC downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ name = "gv-core"
 version = "0.3.0"
 dependencies = [
  "async-compat",
+ "async-compression",
  "async-trait",
  "bigtools",
  "bytes",
@@ -1143,6 +1144,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "twobit",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "3"
 # Non-local crates
 
 async-compat = "0"
+async-compression = { version = "0.4", features = ["gzip", "tokio"] }
 async-trait = "0"
 bigtools = "0"
 bytes = "1"
@@ -21,7 +22,7 @@ nom = "8"
 noodles = { version = "0", features = ["async", "bam", "bed", "bgzf", "core", "cram", "fasta", "sam", "vcf"] }
 opendal = { version = "0.53.3", default-features = false, features = ["services-s3"] }
 ratatui = "0.29"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
@@ -29,7 +30,9 @@ shellexpand = "3.1"
 sqlx = { version = "0.7", features = ["mysql", "sqlite", "runtime-tokio-rustls"] }
 strum = { version = "0.27", features = ["derive"] }
 thiserror = { version = "2" }
+tempfile = "3"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"] }
 twobit = "0"
 url = "2.5.4"
 

--- a/crates/gv-core/Cargo.toml
+++ b/crates/gv-core/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/zeqianli/tgv"
 
 [dependencies]
 async-compat.workspace = true
+async-compression.workspace = true
 async-trait.workspace = true
 bigtools.workspace = true
 bytes.workspace = true
@@ -29,7 +30,9 @@ shellexpand.workspace = true
 sqlx.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 twobit.workspace = true
 url.workspace = true
 

--- a/crates/gv-core/src/error.rs
+++ b/crates/gv-core/src/error.rs
@@ -1,4 +1,5 @@
 use bigtools::{BBIReadError, BigBedReadOpenError};
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -12,6 +13,38 @@ pub enum TGVError {
 
     #[error("SQLx error: {0}")]
     SqlxError(#[from] sqlx::Error),
+
+    #[error(
+        "The UCSC MariaDB download and HTTPS fallback failed. MariaDB: {mysql}. HTTPS: {https}."
+    )]
+    UcscDownloadFallbackError {
+        mysql: Box<TGVError>,
+        https: Box<TGVError>,
+    },
+
+    #[error("Failed to {operation} from {url}: {source}")]
+    UcscHttpRequestError {
+        operation: &'static str,
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[error("Failed to read the UCSC HTTPS dump for table {table} from {url}: {source}")]
+    UcscTableReadError {
+        table: String,
+        url: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to {operation} {path}: {source}")]
+    FileOperationError {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("JSON serialization error: {0}")]
     JsonSerializationError(#[from] serde_json::Error),

--- a/crates/gv-core/src/error.rs
+++ b/crates/gv-core/src/error.rs
@@ -38,7 +38,7 @@ pub enum TGVError {
         source: std::io::Error,
     },
 
-    #[error("Failed to {operation} {path}: {source}")]
+    #[error("Failed to {operation} {}: {source}", path.display())]
     FileOperationError {
         operation: &'static str,
         path: PathBuf,

--- a/crates/gv-core/src/tracks/downloader.rs
+++ b/crates/gv-core/src/tracks/downloader.rs
@@ -37,6 +37,14 @@ enum UCSCColumnType {
     String,
 }
 
+#[derive(Debug, PartialEq)]
+enum UCSCFieldValue {
+    Integer(Option<i64>),
+    Float(Option<f64>),
+    Blob(Option<Vec<u8>>),
+    String(Option<String>),
+}
+
 impl UCSCColumnType {
     fn to_sqlite_type(&self) -> &str {
         match self {
@@ -46,6 +54,82 @@ impl UCSCColumnType {
             UCSCColumnType::Blob => "BLOB",
             UCSCColumnType::String => "TEXT",
         }
+    }
+}
+
+fn validate_https_column_count(
+    field_count: usize,
+    expected_column_count: usize,
+    table_name: &str,
+    row_number: usize,
+) -> Result<(), TGVError> {
+    if field_count != expected_column_count {
+        return Err(TGVError::ParsingError(format!(
+            "The UCSC {table_name} dump has {field_count} columns on row {row_number}; expected {expected_column_count}."
+        )));
+    }
+    Ok(())
+}
+
+fn parse_https_field(
+    field: &[u8],
+    column_type: UCSCColumnType,
+    table_name: &str,
+    column_name: &str,
+    row_number: usize,
+) -> Result<UCSCFieldValue, TGVError> {
+    let is_null = field == b"\\N";
+    match column_type {
+        UCSCColumnType::UnsignedInt | UCSCColumnType::Int => Ok(UCSCFieldValue::Integer(
+            (!is_null)
+                .then(|| {
+                    std::str::from_utf8(field)
+                        .map_err(|error| {
+                            TGVError::ParsingError(format!(
+                                "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
+                            ))
+                        })?
+                        .parse::<i64>()
+                        .map_err(|error| {
+                            TGVError::ParsingError(format!(
+                                "The UCSC {table_name}.{column_name} value on row {row_number} is not an integer: {error}."
+                            ))
+                        })
+                })
+                .transpose()?,
+        )),
+        UCSCColumnType::Float => Ok(UCSCFieldValue::Float(
+            (!is_null)
+                .then(|| {
+                    std::str::from_utf8(field)
+                        .map_err(|error| {
+                            TGVError::ParsingError(format!(
+                                "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
+                            ))
+                        })?
+                        .parse::<f64>()
+                        .map_err(|error| {
+                            TGVError::ParsingError(format!(
+                                "The UCSC {table_name}.{column_name} value on row {row_number} is not a number: {error}."
+                            ))
+                        })
+                })
+                .transpose()?,
+        )),
+        UCSCColumnType::Blob => Ok(UCSCFieldValue::Blob((!is_null).then(|| field.to_vec()))),
+        UCSCColumnType::String => Ok(UCSCFieldValue::String(
+            (!is_null)
+                .then(|| {
+                    std::str::from_utf8(field)
+                        .map_err(|error| {
+                            TGVError::ParsingError(format!(
+                                "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
+                            ))
+                        })
+                        .map(str::to_owned)
+                })
+                .transpose()?,
+        )),
     }
 }
 
@@ -364,77 +448,21 @@ impl UCSCDownloader {
             }
 
             let fields = line.split(|byte| *byte == b'\t').collect::<Vec<_>>();
-            if fields.len() != columns.len() {
-                return Err(TGVError::ParsingError(format!(
-                    "The UCSC {table_name} dump has {} columns on row {row_number}; expected {}.",
-                    fields.len(),
-                    columns.len()
-                )));
-            }
+            validate_https_column_count(fields.len(), columns.len(), table_name, row_number)?;
 
             let mut query = sqlx::query(&insert_sql);
             for ((column_name, column_type), field) in columns.iter().zip(fields) {
-                let is_null = field == b"\\N";
-                query = match column_type {
-                    UCSCColumnType::UnsignedInt | UCSCColumnType::Int => {
-                        let value = if is_null {
-                            None
-                        } else {
-                            Some(
-                                std::str::from_utf8(field)
-                                    .map_err(|error| {
-                                        TGVError::ParsingError(format!(
-                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
-                                        ))
-                                    })?
-                                    .parse::<i64>()
-                                    .map_err(|error| {
-                                        TGVError::ParsingError(format!(
-                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not an integer: {error}."
-                                        ))
-                                    })?,
-                            )
-                        };
-                        query.bind(value)
-                    }
-                    UCSCColumnType::Float => {
-                        let value = if is_null {
-                            None
-                        } else {
-                            Some(
-                                std::str::from_utf8(field)
-                                    .map_err(|error| {
-                                        TGVError::ParsingError(format!(
-                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
-                                        ))
-                                    })?
-                                    .parse::<f64>()
-                                    .map_err(|error| {
-                                        TGVError::ParsingError(format!(
-                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not a number: {error}."
-                                        ))
-                                    })?,
-                            )
-                        };
-                        query.bind(value)
-                    }
-                    UCSCColumnType::Blob => query.bind((!is_null).then(|| field.to_vec())),
-                    UCSCColumnType::String => {
-                        let value = if is_null {
-                            None
-                        } else {
-                            Some(
-                                std::str::from_utf8(field)
-                                    .map_err(|error| {
-                                        TGVError::ParsingError(format!(
-                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
-                                        ))
-                                    })?
-                                    .to_owned(),
-                            )
-                        };
-                        query.bind(value)
-                    }
+                query = match parse_https_field(
+                    field,
+                    *column_type,
+                    table_name,
+                    column_name,
+                    row_number,
+                )? {
+                    UCSCFieldValue::Integer(value) => query.bind(value),
+                    UCSCFieldValue::Float(value) => query.bind(value),
+                    UCSCFieldValue::Blob(value) => query.bind(value),
+                    UCSCFieldValue::String(value) => query.bind(value),
                 };
             }
             query.execute(&mut **transaction).await?;
@@ -1433,4 +1461,83 @@ fn get_preferred_track_name_from_vec(names: &Vec<String>) -> Result<Option<Strin
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(b"42", UCSCColumnType::UnsignedInt, UCSCFieldValue::Integer(Some(42)))]
+    #[case(
+        b"-42",
+        UCSCColumnType::Int,
+        UCSCFieldValue::Integer(Some(-42))
+    )]
+    #[case(b"3.5", UCSCColumnType::Float, UCSCFieldValue::Float(Some(3.5)))]
+    #[case(
+        b"data",
+        UCSCColumnType::Blob,
+        UCSCFieldValue::Blob(Some(b"data".to_vec()))
+    )]
+    #[case(
+        b"chr1",
+        UCSCColumnType::String,
+        UCSCFieldValue::String(Some("chr1".to_owned()))
+    )]
+    fn parses_valid_https_fields(
+        #[case] field: &[u8],
+        #[case] column_type: UCSCColumnType,
+        #[case] expected: UCSCFieldValue,
+    ) {
+        assert_eq!(
+            parse_https_field(field, column_type, "chromInfo", "chrom", 3).unwrap(),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case(b"\\N", UCSCColumnType::UnsignedInt, UCSCFieldValue::Integer(None))]
+    #[case(b"\\N", UCSCColumnType::Float, UCSCFieldValue::Float(None))]
+    #[case(b"\\N", UCSCColumnType::Blob, UCSCFieldValue::Blob(None))]
+    #[case(b"\\N", UCSCColumnType::String, UCSCFieldValue::String(None))]
+    fn parses_null_https_fields(
+        #[case] field: &[u8],
+        #[case] column_type: UCSCColumnType,
+        #[case] expected: UCSCFieldValue,
+    ) {
+        assert_eq!(
+            parse_https_field(field, column_type, "chromInfo", "chrom", 3).unwrap(),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case(b"\xff", UCSCColumnType::String, "is not UTF-8")]
+    #[case(b"not-a-number", UCSCColumnType::UnsignedInt, "is not an integer")]
+    #[case(b"not-a-number", UCSCColumnType::Float, "is not a number")]
+    fn rejects_invalid_https_fields(
+        #[case] field: &[u8],
+        #[case] column_type: UCSCColumnType,
+        #[case] expected_message: &str,
+    ) {
+        let error = parse_https_field(field, column_type, "chromInfo", "chrom", 3)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains(expected_message), "{error}");
+    }
+
+    #[test]
+    fn rejects_an_incorrect_https_column_count() {
+        let error = validate_https_column_count(2, 3, "chromInfo", 3)
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(
+            error,
+            "Parsing error: The UCSC chromInfo dump has 2 columns on row 3; expected 3."
+        );
+    }
 }

--- a/crates/gv-core/src/tracks/downloader.rs
+++ b/crates/gv-core/src/tracks/downloader.rs
@@ -337,16 +337,35 @@ impl UCSCDownloader {
             ),
         ] {
             let url = format!("{database_url}/{table_name}.txt.gz");
-            let response = client
-                .get(&url)
-                .send()
-                .await
-                .and_then(Response::error_for_status)
-                .map_err(|source| TGVError::UcscHttpRequestError {
-                    operation: "download a UCSC table dump",
-                    url: url.clone(),
-                    source,
-                })?;
+            let response =
+                client
+                    .get(&url)
+                    .send()
+                    .await
+                    .map_err(|source| TGVError::UcscHttpRequestError {
+                        operation: "check for a UCSC table dump",
+                        url: url.clone(),
+                        source,
+                    })?;
+            if response.status() == StatusCode::NOT_FOUND
+                && matches!(table_name, "chromAlias" | "cytoBandIdeo")
+            {
+                Self::create_https_table(table_name, columns, &mut transaction).await?;
+                log::info!(
+                    "UCSC HTTPS table dump is unavailable; created an empty table: reference={} table={}",
+                    self.reference,
+                    table_name
+                );
+                continue;
+            }
+            let response =
+                response
+                    .error_for_status()
+                    .map_err(|source| TGVError::UcscHttpRequestError {
+                        operation: "download a UCSC table dump",
+                        url: url.clone(),
+                        source,
+                    })?;
             self.import_https_table(table_name, columns, &url, response, &mut transaction)
                 .await?;
         }
@@ -431,17 +450,7 @@ impl UCSCDownloader {
     ) -> Result<(), TGVError> {
         println!("Importing {table_name} over HTTPS...");
 
-        let column_definitions = columns
-            .iter()
-            .map(|(name, column_type)| format!("{name} {}", column_type.to_sqlite_type()))
-            .collect::<Vec<_>>()
-            .join(", ");
-        sqlx::query(&format!("DROP TABLE IF EXISTS {table_name}"))
-            .execute(&mut **transaction)
-            .await?;
-        sqlx::query(&format!("CREATE TABLE {table_name} ({column_definitions})"))
-            .execute(&mut **transaction)
-            .await?;
+        Self::create_https_table(table_name, columns, transaction).await?;
 
         let column_names = columns
             .iter()
@@ -508,6 +517,25 @@ impl UCSCDownloader {
             )));
         }
         println!("Imported {table_name} ({row_number} rows)");
+        Ok(())
+    }
+
+    async fn create_https_table(
+        table_name: &str,
+        columns: &[(&str, UCSCColumnType)],
+        transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    ) -> Result<(), TGVError> {
+        let column_definitions = columns
+            .iter()
+            .map(|(name, column_type)| format!("{name} {}", column_type.to_sqlite_type()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        sqlx::query(&format!("DROP TABLE IF EXISTS {table_name}"))
+            .execute(&mut **transaction)
+            .await?;
+        sqlx::query(&format!("CREATE TABLE {table_name} ({column_definitions})"))
+            .execute(&mut **transaction)
+            .await?;
         Ok(())
     }
 

--- a/crates/gv-core/src/tracks/downloader.rs
+++ b/crates/gv-core/src/tracks/downloader.rs
@@ -16,6 +16,8 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio_util::io::StreamReader;
 
 const UCSC_MARIADB_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const UCSC_HTTPS_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const UCSC_HTTPS_REQUEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// Download data from UCSC mariaDB to a local sqlite file.
 pub struct UCSCDownloader {
@@ -178,7 +180,10 @@ impl UCSCDownloader {
 
     /// Import UCSC's compressed table dumps when direct MariaDB access is unavailable.
     async fn download_from_https(&self, sqlite_pool: &SqlitePool) -> Result<(), TGVError> {
-        let client = Client::new();
+        let client = Client::builder()
+            .connect_timeout(UCSC_HTTPS_CONNECT_TIMEOUT)
+            .timeout(UCSC_HTTPS_REQUEST_TIMEOUT)
+            .build()?;
         let database_url = format!(
             "https://hgdownload.soe.ucsc.edu/goldenPath/{}/database",
             self.reference
@@ -878,7 +883,10 @@ impl UCSCDownloader {
             return Ok(local_path);
         }
 
-        let client = Client::new();
+        let client = Client::builder()
+            .connect_timeout(UCSC_HTTPS_CONNECT_TIMEOUT)
+            .timeout(UCSC_HTTPS_REQUEST_TIMEOUT)
+            .build()?;
 
         println!("Downloading file: {}", local_path.display());
 

--- a/crates/gv-core/src/tracks/downloader.rs
+++ b/crates/gv-core/src/tracks/downloader.rs
@@ -25,6 +25,22 @@ pub struct UCSCDownloader {
 
     /// TGV main cache directory. Reference data are stored in cache_dir/reference_name/.
     cache_dir: String,
+
+    source: UCSCDownloadSource,
+}
+
+/// The source to use when downloading UCSC assembly data.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum UCSCDownloadSource {
+    /// Try MariaDB first, then fall back to HTTPS when it fails.
+    #[default]
+    Automatic,
+
+    /// Only download from UCSC MariaDB.
+    MariaDbOnly,
+
+    /// Only download from UCSC HTTPS table dumps.
+    HttpsOnly,
 }
 
 /// UCSC column type. Used to map MySQL types to SQLite types.
@@ -134,13 +150,18 @@ fn parse_https_field(
 }
 
 impl UCSCDownloader {
-    pub fn new(reference: Reference, cache_dir: &str) -> Result<Self, TGVError> {
+    pub fn new(
+        reference: Reference,
+        cache_dir: &str,
+        source: UCSCDownloadSource,
+    ) -> Result<Self, TGVError> {
         let cache_dir = reference.cache_dir(cache_dir);
         std::fs::create_dir_all(Path::new(&cache_dir))
             .map_err(|e| TGVError::IOError(format!("Failed to create genome directory: {}", e)))?;
         Ok(Self {
             reference: reference.clone(),
             cache_dir,
+            source,
         })
     }
 
@@ -199,6 +220,19 @@ impl UCSCDownloader {
         reference: &Reference,
         sqlite_pool: &Pool<Sqlite>,
     ) -> Result<(), TGVError> {
+        if self.source == UCSCDownloadSource::MariaDbOnly {
+            self.download_from_mysql(reference, sqlite_pool, &UcscHost::Us)
+                .await?;
+            println!("Successfully downloaded track data for {reference}");
+            return Ok(());
+        }
+
+        if self.source == UCSCDownloadSource::HttpsOnly {
+            self.download_from_https(sqlite_pool).await?;
+            println!("Successfully downloaded track data for {reference}");
+            return Ok(());
+        }
+
         let mysql = match self
             .download_from_mysql(reference, sqlite_pool, &UcscHost::Us)
             .await

--- a/crates/gv-core/src/tracks/downloader.rs
+++ b/crates/gv-core/src/tracks/downloader.rs
@@ -1,6 +1,9 @@
 use crate::tracks::{TRACK_PREFERENCES, UcscApiTrackService, UcscDbTrackService};
 use crate::{error::TGVError, reference::Reference, tracks::UcscHost};
+use async_compression::tokio::bufread::GzipDecoder;
 use bigtools::BigBedRead;
+use futures::TryStreamExt;
+use reqwest::{Client, Response, StatusCode};
 use sqlx::{
     MySqlPool, Pool, Row,
     mysql::MySqlPoolOptions,
@@ -8,7 +11,12 @@ use sqlx::{
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio_util::io::StreamReader;
+
+const UCSC_MARIADB_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Download data from UCSC mariaDB to a local sqlite file.
 pub struct UCSCDownloader {
     reference: Reference,
@@ -18,7 +26,7 @@ pub struct UCSCDownloader {
 }
 
 /// UCSC column type. Used to map MySQL types to SQLite types.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 enum UCSCColumnType {
     UnsignedInt,
     Int,
@@ -105,38 +113,334 @@ impl UCSCDownloader {
         reference: &Reference,
         sqlite_pool: &Pool<Sqlite>,
     ) -> Result<(), TGVError> {
-        // Connect to MariaDB
-        let mysql_url = UcscDbTrackService::get_mysql_url(&self.reference, &UcscHost::Us)?;
+        let mysql = match self
+            .download_from_mysql(reference, sqlite_pool, &UcscHost::Us)
+            .await
+        {
+            Ok(()) => {
+                println!("Successfully downloaded track data for {reference}");
+                return Ok(());
+            }
+            Err(error) => error,
+        };
+        eprintln!("UCSC MariaDB is unavailable. Falling back to HTTPS downloads.");
+
+        if let Err(https) = self.download_from_https(sqlite_pool).await {
+            return Err(TGVError::UcscDownloadFallbackError {
+                mysql: Box::new(mysql),
+                https: Box::new(https),
+            });
+        }
+        println!("Successfully downloaded track data for {reference}");
+        Ok(())
+    }
+
+    async fn download_from_mysql(
+        &self,
+        reference: &Reference,
+        sqlite_pool: &SqlitePool,
+        host: &UcscHost,
+    ) -> Result<(), TGVError> {
+        let mysql_url = UcscDbTrackService::get_mysql_url(&self.reference, host)?;
         log::info!(
-            "Database connect: database=ucsc-mysql connection={} context=download reference={}",
+            "Database connect: database=ucsc-mysql connection={} context=download reference={} host={}",
             mysql_url,
-            reference
+            reference,
+            host.to_string()
         );
         let started = Instant::now();
         let mysql_pool = MySqlPoolOptions::new()
             .max_connections(5)
+            .acquire_timeout(UCSC_MARIADB_CONNECT_TIMEOUT)
             .connect(&mysql_url)
             .await?;
         log::info!(
-            "Database connect result: database=ucsc-mysql context=download reference={} elapsed_ms={}",
+            "Database connect result: database=ucsc-mysql context=download reference={} host={} elapsed_ms={}",
             reference,
+            host.to_string(),
             started.elapsed().as_millis()
         );
 
-        self.transfer_table(&mysql_pool, sqlite_pool, "chromInfo")
-            .await?
-            .transfer_table(&mysql_pool, sqlite_pool, "chromAlias")
-            .await?
-            .transfer_table(&mysql_pool, sqlite_pool, "cytoBandIdeo")
-            .await?
-            .transfer_gene_tracks(&mysql_pool, sqlite_pool)
+        let mut transaction = sqlite_pool.begin().await?;
+        self.transfer_table(&mysql_pool, &mut transaction, "chromInfo")
+            .await?;
+        self.transfer_table(&mysql_pool, &mut transaction, "chromAlias")
+            .await?;
+        self.transfer_table(&mysql_pool, &mut transaction, "cytoBandIdeo")
+            .await?;
+        self.transfer_gene_tracks(&mysql_pool, &mut transaction)
+            .await?;
+        self.download_genomes(&mut transaction).await?;
+        transaction.commit().await?;
+        mysql_pool.close().await;
+        Ok(())
+    }
+
+    /// Import UCSC's compressed table dumps when direct MariaDB access is unavailable.
+    async fn download_from_https(&self, sqlite_pool: &SqlitePool) -> Result<(), TGVError> {
+        let client = Client::new();
+        let database_url = format!(
+            "https://hgdownload.soe.ucsc.edu/goldenPath/{}/database",
+            self.reference
+        );
+        let mut transaction = sqlite_pool.begin().await?;
+
+        for (table_name, columns) in [
+            (
+                "chromInfo",
+                &[
+                    ("chrom", UCSCColumnType::String),
+                    ("size", UCSCColumnType::UnsignedInt),
+                    ("fileName", UCSCColumnType::String),
+                ] as &[(&str, UCSCColumnType)],
+            ),
+            (
+                "chromAlias",
+                &[
+                    ("alias", UCSCColumnType::String),
+                    ("chrom", UCSCColumnType::String),
+                    ("source", UCSCColumnType::String),
+                ] as &[(&str, UCSCColumnType)],
+            ),
+            (
+                "cytoBandIdeo",
+                &[
+                    ("chrom", UCSCColumnType::String),
+                    ("chromStart", UCSCColumnType::UnsignedInt),
+                    ("chromEnd", UCSCColumnType::UnsignedInt),
+                    ("name", UCSCColumnType::String),
+                    ("gieStain", UCSCColumnType::String),
+                ] as &[(&str, UCSCColumnType)],
+            ),
+        ] {
+            let url = format!("{database_url}/{table_name}.txt.gz");
+            let response = client
+                .get(&url)
+                .send()
+                .await
+                .and_then(Response::error_for_status)
+                .map_err(|source| TGVError::UcscHttpRequestError {
+                    operation: "download a UCSC table dump",
+                    url: url.clone(),
+                    source,
+                })?;
+            self.import_https_table(table_name, columns, &url, response, &mut transaction)
+                .await?;
+        }
+
+        let mut imported_gene_track = None;
+        for table_name in TRACK_PREFERENCES {
+            let url = format!("{database_url}/{table_name}.txt.gz");
+            let response =
+                client
+                    .get(&url)
+                    .send()
+                    .await
+                    .map_err(|source| TGVError::UcscHttpRequestError {
+                        operation: "check for a UCSC gene table dump",
+                        url: url.clone(),
+                        source,
+                    })?;
+            if response.status() == StatusCode::NOT_FOUND {
+                continue;
+            }
+            let response =
+                response
+                    .error_for_status()
+                    .map_err(|source| TGVError::UcscHttpRequestError {
+                        operation: "download a UCSC gene table dump",
+                        url: url.clone(),
+                        source,
+                    })?;
+            self.import_https_table(
+                table_name,
+                &[
+                    ("bin", UCSCColumnType::UnsignedInt),
+                    ("name", UCSCColumnType::String),
+                    ("chrom", UCSCColumnType::String),
+                    ("strand", UCSCColumnType::String),
+                    ("txStart", UCSCColumnType::UnsignedInt),
+                    ("txEnd", UCSCColumnType::UnsignedInt),
+                    ("cdsStart", UCSCColumnType::UnsignedInt),
+                    ("cdsEnd", UCSCColumnType::UnsignedInt),
+                    ("exonCount", UCSCColumnType::UnsignedInt),
+                    ("exonStarts", UCSCColumnType::Blob),
+                    ("exonEnds", UCSCColumnType::Blob),
+                    ("score", UCSCColumnType::Int),
+                    ("name2", UCSCColumnType::String),
+                    ("cdsStartStat", UCSCColumnType::String),
+                    ("cdsEndStat", UCSCColumnType::String),
+                    ("exonFrames", UCSCColumnType::Blob),
+                ],
+                &url,
+                response,
+                &mut transaction,
+            )
+            .await?;
+            imported_gene_track = Some(table_name);
+            break;
+        }
+
+        let imported_gene_track = imported_gene_track.ok_or_else(|| {
+            TGVError::IOError(format!(
+                "No supported gene table dump is available for {}.",
+                self.reference
+            ))
+        })?;
+        log::info!(
+            "Imported UCSC HTTPS table dumps: reference={} gene_track={}",
+            self.reference,
+            imported_gene_track
+        );
+
+        self.download_genomes(&mut transaction).await?;
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    async fn import_https_table(
+        &self,
+        table_name: &str,
+        columns: &[(&str, UCSCColumnType)],
+        url: &str,
+        response: Response,
+        transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    ) -> Result<(), TGVError> {
+        println!("Importing {table_name} over HTTPS...");
+
+        let column_definitions = columns
+            .iter()
+            .map(|(name, column_type)| format!("{name} {}", column_type.to_sqlite_type()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        sqlx::query(&format!("DROP TABLE IF EXISTS {table_name}"))
+            .execute(&mut **transaction)
+            .await?;
+        sqlx::query(&format!("CREATE TABLE {table_name} ({column_definitions})"))
+            .execute(&mut **transaction)
             .await?;
 
-        mysql_pool.close().await;
+        let column_names = columns
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let placeholders = vec!["?"; columns.len()].join(", ");
+        let insert_sql =
+            format!("INSERT INTO {table_name} ({column_names}) VALUES ({placeholders})");
 
-        self.download_genomes(sqlite_pool).await?;
+        let stream = response.bytes_stream().map_err(std::io::Error::other);
+        let reader = StreamReader::new(stream);
+        let decoder = GzipDecoder::new(BufReader::new(reader));
+        let mut reader = BufReader::new(decoder);
+        let mut line = Vec::new();
+        let mut row_number = 0usize;
 
-        println!("Successfully downloaded track data for {}", reference,);
+        loop {
+            line.clear();
+            if reader
+                .read_until(b'\n', &mut line)
+                .await
+                .map_err(|source| TGVError::UcscTableReadError {
+                    table: table_name.to_owned(),
+                    url: url.to_owned(),
+                    source,
+                })?
+                == 0
+            {
+                break;
+            }
+            row_number += 1;
+            if line.last() == Some(&b'\n') {
+                line.pop();
+            }
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+
+            let fields = line.split(|byte| *byte == b'\t').collect::<Vec<_>>();
+            if fields.len() != columns.len() {
+                return Err(TGVError::ParsingError(format!(
+                    "The UCSC {table_name} dump has {} columns on row {row_number}; expected {}.",
+                    fields.len(),
+                    columns.len()
+                )));
+            }
+
+            let mut query = sqlx::query(&insert_sql);
+            for ((column_name, column_type), field) in columns.iter().zip(fields) {
+                let is_null = field == b"\\N";
+                query = match column_type {
+                    UCSCColumnType::UnsignedInt | UCSCColumnType::Int => {
+                        let value = if is_null {
+                            None
+                        } else {
+                            Some(
+                                std::str::from_utf8(field)
+                                    .map_err(|error| {
+                                        TGVError::ParsingError(format!(
+                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
+                                        ))
+                                    })?
+                                    .parse::<i64>()
+                                    .map_err(|error| {
+                                        TGVError::ParsingError(format!(
+                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not an integer: {error}."
+                                        ))
+                                    })?,
+                            )
+                        };
+                        query.bind(value)
+                    }
+                    UCSCColumnType::Float => {
+                        let value = if is_null {
+                            None
+                        } else {
+                            Some(
+                                std::str::from_utf8(field)
+                                    .map_err(|error| {
+                                        TGVError::ParsingError(format!(
+                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
+                                        ))
+                                    })?
+                                    .parse::<f64>()
+                                    .map_err(|error| {
+                                        TGVError::ParsingError(format!(
+                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not a number: {error}."
+                                        ))
+                                    })?,
+                            )
+                        };
+                        query.bind(value)
+                    }
+                    UCSCColumnType::Blob => query.bind((!is_null).then(|| field.to_vec())),
+                    UCSCColumnType::String => {
+                        let value = if is_null {
+                            None
+                        } else {
+                            Some(
+                                std::str::from_utf8(field)
+                                    .map_err(|error| {
+                                        TGVError::ParsingError(format!(
+                                            "The UCSC {table_name}.{column_name} value on row {row_number} is not UTF-8: {error}."
+                                        ))
+                                    })?
+                                    .to_owned(),
+                            )
+                        };
+                        query.bind(value)
+                    }
+                };
+            }
+            query.execute(&mut **transaction).await?;
+        }
+
+        if row_number == 0 {
+            return Err(TGVError::IOError(format!(
+                "The UCSC {table_name} HTTPS dump is empty."
+            )));
+        }
+        println!("Imported {table_name} ({row_number} rows)");
         Ok(())
     }
 
@@ -274,7 +578,7 @@ impl UCSCDownloader {
     async fn transfer_table(
         &self,
         mysql_pool: &MySqlPool,
-        sqlite_pool: &SqlitePool,
+        sqlite_transaction: &mut sqlx::Transaction<'_, Sqlite>,
         table_name: &str,
     ) -> Result<&Self, TGVError> {
         let mut column_types: HashMap<String, UCSCColumnType> = HashMap::new();
@@ -371,7 +675,9 @@ impl UCSCDownloader {
             table_name
         );
         let started = Instant::now();
-        sqlx::query(&drop_sql).execute(sqlite_pool).await?;
+        sqlx::query(&drop_sql)
+            .execute(&mut **sqlite_transaction)
+            .await?;
         log::info!(
             "Database query result: database=local-sqlite context=reset transferred table table={} elapsed_ms={}",
             table_name,
@@ -385,7 +691,9 @@ impl UCSCDownloader {
             table_name
         );
         let started = Instant::now();
-        sqlx::query(&create_sql).execute(sqlite_pool).await?;
+        sqlx::query(&create_sql)
+            .execute(&mut **sqlite_transaction)
+            .await?;
         log::info!(
             "Database query result: database=local-sqlite context=create transferred table table={} elapsed_ms={}",
             table_name,
@@ -427,7 +735,6 @@ impl UCSCDownloader {
             table_name
         );
 
-        let mut transaction: sqlx::Transaction<'_, sqlx::Sqlite> = sqlite_pool.begin().await?;
         let started = Instant::now();
         for row in &rows {
             let mut query = sqlx::query(&insert_sql);
@@ -456,10 +763,8 @@ impl UCSCDownloader {
                     }
                 }
             }
-            query.execute(&mut *transaction).await?;
+            query.execute(&mut **sqlite_transaction).await?;
         }
-
-        transaction.commit().await?;
         log::info!(
             "Database batch result: database=local-sqlite context=insert transferred table rows table={} rows={} elapsed_ms={}",
             table_name,
@@ -480,7 +785,7 @@ impl UCSCDownloader {
     async fn transfer_gene_tracks(
         &self,
         mysql_pool: &MySqlPool,
-        sqlite_pool: &SqlitePool,
+        sqlite_transaction: &mut sqlx::Transaction<'_, Sqlite>,
     ) -> Result<&Self, TGVError> {
         // Get list of available gene tracks
         let sql = "SHOW TABLES";
@@ -504,7 +809,7 @@ impl UCSCDownloader {
         let preferred_track = get_preferred_track_name_from_vec(&available_tracks)?;
 
         if let Some(track_name) = preferred_track {
-            self.transfer_table(mysql_pool, sqlite_pool, &track_name)
+            self.transfer_table(mysql_pool, sqlite_transaction, &track_name)
                 .await?;
         } else {
             println!("No preferred gene track found");
@@ -515,7 +820,10 @@ impl UCSCDownloader {
 
     /// Used for UCSC assembly download.
     /// Query the chromInfo table to get the genome file urls and download them.
-    async fn download_genomes(&self, sqlite_pool: &SqlitePool) -> Result<(), TGVError> {
+    async fn download_genomes(
+        &self,
+        sqlite_transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    ) -> Result<(), TGVError> {
         println!("Downloading genome files...");
 
         // Query SQLite for unique fileName values from chromInfo table
@@ -526,7 +834,9 @@ impl UCSCDownloader {
             sql
         );
         let started = Instant::now();
-        let rows = sqlx::query(sql).fetch_all(sqlite_pool).await?;
+        let rows = sqlx::query(sql)
+            .fetch_all(&mut **sqlite_transaction)
+            .await?;
         log::info!(
             "Database query result: database=local-sqlite context=find genome files to download rows={} elapsed_ms={}",
             rows.len(),
@@ -540,7 +850,10 @@ impl UCSCDownloader {
 
         for row in rows {
             let file_name: String = row.try_get("fileName")?;
-            let download_url = format!("http://hgdownload.soe.ucsc.edu/{}", file_name);
+            let download_url = format!(
+                "https://hgdownload.soe.ucsc.edu/{}",
+                file_name.trim_start_matches('/')
+            );
 
             self.download_to_directory(&download_url).await?;
         }
@@ -552,8 +865,20 @@ impl UCSCDownloader {
     /// Download a file to a directory with the same filename.
     /// Skip if file already exists. Note that no cache invalidation here. TODO.
     async fn download_to_directory(&self, url: &str) -> Result<PathBuf, TGVError> {
-        let local_path = Path::new(&self.cache_dir).join(url.split("/").last().unwrap());
-        let client = reqwest::Client::new();
+        let file_name = url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| {
+                TGVError::ValueError(format!("The download URL has no file name: {url}"))
+            })?;
+        let local_path = Path::new(&self.cache_dir).join(file_name);
+        if local_path.exists() {
+            println!("Already downloaded: {}", local_path.display());
+            return Ok(local_path);
+        }
+
+        let client = Client::new();
 
         println!("Downloading file: {}", local_path.display());
 
@@ -562,56 +887,87 @@ impl UCSCDownloader {
             url,
             local_path.display()
         );
-        // Download the file
         let started = Instant::now();
-        match client.get(url).send().await {
-            Ok(response) => {
-                log::info!(
-                    "HTTP response: status={} url={} context=download file elapsed_ms={}",
-                    response.status(),
-                    url,
-                    started.elapsed().as_millis()
-                );
-                if response.status().is_success() {
-                    let content = response.bytes().await.map_err(|e| {
-                        TGVError::IOError(format!("Failed to read response bytes: {}", e))
-                    })?;
-                    log::debug!(
-                        "Downloaded HTTP response body: url={} bytes={} local_path={}",
-                        url,
-                        content.len(),
-                        local_path.display()
-                    );
+        let mut response = client
+            .get(url)
+            .send()
+            .await
+            .and_then(Response::error_for_status)
+            .map_err(|source| TGVError::UcscHttpRequestError {
+                operation: "download a UCSC file",
+                url: url.to_owned(),
+                source,
+            })?;
+        log::info!(
+            "HTTP response: status={} url={} context=download file elapsed_ms={}",
+            response.status(),
+            url,
+            started.elapsed().as_millis()
+        );
 
-                    // Write file to disk
-                    std::fs::write(&local_path, content).map_err(|e| {
-                        TGVError::IOError(format!(
-                            "Failed to write file {}: {}",
-                            local_path.display(),
-                            e
-                        ))
-                    })?;
-
-                    println!("Downloaded: {}", local_path.display());
-                } else {
-                    println!(
-                        "Failed to download {}: HTTP {}",
-                        local_path.display(),
-                        response.status()
-                    );
+        let temporary_file =
+            tempfile::NamedTempFile::new_in(&self.cache_dir).map_err(|source| {
+                TGVError::FileOperationError {
+                    operation: "create a temporary download in",
+                    path: PathBuf::from(&self.cache_dir),
+                    source,
                 }
-            }
-            Err(e) => {
-                log::warn!(
-                    "HTTP request failed: url={} error={} elapsed_ms={}",
+            })?;
+        let (temporary_file, temporary_path) = temporary_file.into_parts();
+        let mut file = tokio::fs::File::from_std(temporary_file);
+        let mut downloaded_bytes = 0usize;
+        while let Some(chunk) =
+            response
+                .chunk()
+                .await
+                .map_err(|source| TGVError::UcscHttpRequestError {
+                    operation: "read a UCSC file response",
+                    url: url.to_owned(),
+                    source,
+                })?
+        {
+            file.write_all(&chunk)
+                .await
+                .map_err(|source| TGVError::FileOperationError {
+                    operation: "write the temporary download",
+                    path: temporary_path.to_path_buf(),
+                    source,
+                })?;
+            downloaded_bytes += chunk.len();
+        }
+        file.flush()
+            .await
+            .map_err(|source| TGVError::FileOperationError {
+                operation: "flush the temporary download",
+                path: temporary_path.to_path_buf(),
+                source,
+            })?;
+        drop(file);
+        match temporary_path.persist_noclobber(&local_path) {
+            Ok(()) => {}
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                log::info!(
+                    "Another download completed first: url={} local_path={}",
                     url,
-                    e,
-                    started.elapsed().as_millis()
+                    local_path.display()
                 );
-                println!("Failed to download {}: {}", local_path.display(), e);
+            }
+            Err(error) => {
+                return Err(TGVError::FileOperationError {
+                    operation: "publish the completed download as",
+                    path: local_path.clone(),
+                    source: error.error,
+                });
             }
         }
+        log::debug!(
+            "Downloaded HTTP response body: url={} bytes={} local_path={}",
+            url,
+            downloaded_bytes,
+            local_path.display()
+        );
 
+        println!("Downloaded: {}", local_path.display());
         Ok(local_path)
     }
 }

--- a/crates/gv-core/src/tracks/mod.rs
+++ b/crates/gv-core/src/tracks/mod.rs
@@ -30,7 +30,7 @@ const TRACK_PREFERENCES: [&str; 5] = [
     "ncbiRefSeqCurated",
     "ncbiRefSeq",
     "ncbiGene",
-    "refGenes",
+    "refGene",
 ];
 
 /// Holds cache for track service queries.

--- a/crates/gv-core/src/tracks/mod.rs
+++ b/crates/gv-core/src/tracks/mod.rs
@@ -581,7 +581,7 @@ impl std::string::ToString for UcscHost {
 impl UcscHost {
     pub fn url(&self) -> String {
         match self {
-            UcscHost::Us => "genome-mysql.soe.ucsc.edu".to_string(),
+            UcscHost::Us => "genome-mysql.gi.ucsc.edu".to_string(),
             UcscHost::Eu => "genome-euro-mysql.soe.ucsc.edu".to_string(),
         }
     }

--- a/crates/gv-core/src/tracks/mod.rs
+++ b/crates/gv-core/src/tracks/mod.rs
@@ -19,7 +19,7 @@ use chrono::Local;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-pub use downloader::UCSCDownloader;
+pub use downloader::{UCSCDownloadSource, UCSCDownloader};
 pub use local_db::LocalDbTrackService;
 pub use ucsc_api::UcscApiTrackService;
 pub use ucsc_db::UcscDbTrackService;

--- a/crates/gv-core/src/tracks/ucsc_db.rs
+++ b/crates/gv-core/src/tracks/ucsc_db.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-const UCSC_HGCENTRAL_URL: &str = "mysql://genome@genome-mysql.soe.ucsc.edu/hgcentral";
+const UCSC_HGCENTRAL_URL: &str = "mysql://genome@genome-mysql.gi.ucsc.edu/hgcentral";
 
 #[derive(Debug)]
 pub struct UcscDbTrackService {

--- a/crates/tgv/src/main.rs
+++ b/crates/tgv/src/main.rs
@@ -29,10 +29,15 @@ async fn main() -> Result<(), TGVError> {
         Some(Commands::Download {
             reference,
             cache_dir,
+            source,
         }) => {
             log::info!("Starting download for reference {reference}");
             let cache_dir = shellexpand::tilde(&cache_dir).to_string();
-            let downloader = UCSCDownloader::new(reference.parse::<Reference>()?, &cache_dir)?;
+            let downloader = UCSCDownloader::new(
+                reference.parse::<Reference>()?,
+                &cache_dir,
+                (*source).into(),
+            )?;
             downloader.download().await?;
             return Ok(());
         }

--- a/crates/tgv/src/mouse.rs
+++ b/crates/tgv/src/mouse.rs
@@ -106,21 +106,18 @@ impl MouseRegister {
                     }
                 } else {
                     // move alignment
-                    match Self::alignment_index_for_area_type(&self.mouse_down_area_type) {
-                        Some(index) => {
-                            if event.column < self.mouse_drag_x {
-                                messages.push(Movement::Right(1).into())
-                            } else if event.column > self.mouse_drag_x {
-                                messages.push(Movement::Left(1).into())
-                            }
-
-                            if event.row > self.mouse_drag_y {
-                                messages.push(Scroll::Up { index, n: 1 }.into())
-                            } else if event.row < self.mouse_drag_y {
-                                messages.push(Scroll::Down { index, n: 1 }.into())
-                            }
+                    if let Some(index) = Self::alignment_index_for_area_type(&self.mouse_down_area_type) {
+                        if event.column < self.mouse_drag_x {
+                            messages.push(Movement::Right(1).into())
+                        } else if event.column > self.mouse_drag_x {
+                            messages.push(Movement::Left(1).into())
                         }
-                        _ => {}
+
+                        if event.row > self.mouse_drag_y {
+                            messages.push(Scroll::Up { index, n: 1 }.into())
+                        } else if event.row < self.mouse_drag_y {
+                            messages.push(Scroll::Down { index, n: 1 }.into())
+                        }
                     }
 
                     self.mouse_drag_x = event.column;

--- a/crates/tgv/src/settings.rs
+++ b/crates/tgv/src/settings.rs
@@ -8,7 +8,7 @@ use gv_core::error::TGVError;
 use gv_core::message::Movement;
 use gv_core::reference::Reference;
 use gv_core::settings::{AlignmentPath, BackendType, BamSource, FilePath};
-use gv_core::tracks::UcscHost;
+use gv_core::tracks::{UCSCDownloadSource, UcscHost};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Eq, PartialEq, ValueEnum)]
@@ -31,6 +31,32 @@ impl From<UcscHostCli> for UcscHost {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum UCSCDownloadSourceCli {
+    /// Try UCSC MariaDB first, then fall back to HTTPS.
+    #[value(name = "auto")]
+    #[default]
+    Automatic,
+
+    /// Only download from UCSC MariaDB.
+    #[value(name = "db")]
+    MariaDbOnly,
+
+    /// Only download from UCSC HTTPS table dumps.
+    #[value(name = "https")]
+    HttpsOnly,
+}
+
+impl From<UCSCDownloadSourceCli> for UCSCDownloadSource {
+    fn from(value: UCSCDownloadSourceCli) -> Self {
+        match value {
+            UCSCDownloadSourceCli::Automatic => Self::Automatic,
+            UCSCDownloadSourceCli::MariaDbOnly => Self::MariaDbOnly,
+            UCSCDownloadSourceCli::HttpsOnly => Self::HttpsOnly,
+        }
+    }
+}
+
 #[derive(Subcommand, Clone, Debug)]
 pub enum Commands {
     /// Download reference data.
@@ -41,6 +67,10 @@ pub enum Commands {
         /// Cache directory.
         #[arg(long = "cache-dir", default_value = "~/.tgv")]
         cache_dir: String,
+
+        /// Select the UCSC download source.
+        #[arg(long, value_enum, default_value_t)]
+        source: UCSCDownloadSourceCli,
     },
 
     /// List reference genomes.

--- a/crates/tgv/tests/online_app.rs
+++ b/crates/tgv/tests/online_app.rs
@@ -36,6 +36,7 @@ async fn online_initialization_succeeds(#[case] bam_path: Option<&str>, #[case] 
 #[ignore = "requires network and third-party services"]
 async fn online_download_integration_test(#[case] reference_str: &str) {
     let reference = reference_str.parse::<Reference>().unwrap();
+    let cache_reference = reference.to_string();
     let temp_dir = TempDir::new().unwrap();
     let temp_dir_str = temp_dir.path().to_str().unwrap();
     let downloader =
@@ -43,10 +44,10 @@ async fn online_download_integration_test(#[case] reference_str: &str) {
 
     downloader.download().await.unwrap();
 
-    assert!(Path::new(temp_dir_str).join(reference_str).exists());
+    assert!(Path::new(temp_dir_str).join(&cache_reference).exists());
     assert!(
         Path::new(temp_dir_str)
-            .join(reference_str)
+            .join(&cache_reference)
             .join("tracks.sqlite")
             .exists()
     );

--- a/crates/tgv/tests/online_app.rs
+++ b/crates/tgv/tests/online_app.rs
@@ -1,6 +1,9 @@
 mod support;
 
-use gv_core::{reference::Reference, tracks::UCSCDownloader};
+use gv_core::{
+    reference::Reference,
+    tracks::{UCSCDownloadSource, UCSCDownloader},
+};
 use rstest::rstest;
 use std::path::Path;
 use support::{AppHarness, test_data_path};
@@ -35,7 +38,8 @@ async fn online_download_integration_test(#[case] reference_str: &str) {
     let reference = reference_str.parse::<Reference>().unwrap();
     let temp_dir = TempDir::new().unwrap();
     let temp_dir_str = temp_dir.path().to_str().unwrap();
-    let downloader = UCSCDownloader::new(reference, temp_dir_str).unwrap();
+    let downloader =
+        UCSCDownloader::new(reference, temp_dir_str, UCSCDownloadSource::Automatic).unwrap();
 
     downloader.download().await.unwrap();
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -5,3 +5,4 @@
 - [Installation](./installation.md)
 - [Usage](./usage.md)
 - [Session files](./session.md)
+- [HTTPS download fallback](./design/https-download-fallback.md)

--- a/doc/src/design/https-download-fallback.md
+++ b/doc/src/design/https-download-fallback.md
@@ -1,0 +1,9 @@
+# HTTPS download fallback
+
+TGV normally builds a local reference cache by querying the UCSC MariaDB server. Some networks block outbound MariaDB traffic on port 3306 while allowing HTTPS, so the downloader gives the MariaDB connection a five-second acquisition timeout, then falls back to UCSC's HTTPS table dumps when the MariaDB download fails. A MariaDB attempt includes both the connection and table transfer; a failure at either stage starts the HTTPS fallback.
+
+The HTTPS backend imports `chromInfo`, `chromAlias`, `cytoBandIdeo`, and the first available preferred gene table. UCSC publishes these tables as gzip-compressed, tab-separated dumps. TGV uses explicit SQLite schemas for the small cache contract instead of translating arbitrary MySQL DDL. This keeps SQLite types predictable for downstream readers, but a future change to a UCSC dump schema must be reflected in the corresponding schema definition in the downloader.
+
+Rows are streamed from the HTTP response, decompressed, and inserted incrementally to bound memory use. All table changes share one SQLite transaction, and TGV downloads every sequence file referenced by `chromInfo` before committing it. A failed table or sequence download therefore leaves the previous database state intact. If both backends fail, TGV reports both the MariaDB error and the HTTPS error.
+
+Sequence downloads use HTTPS and stream their response into a unique temporary file in the cache directory. Publishing uses a no-clobber operation, so concurrent TGV processes cannot write the same temporary file or replace a completed download. If another process publishes the destination first, both downloads treat the completed destination as the cache entry. Existing cache files are retained without revalidation.

--- a/doc/src/design/https-download-fallback.md
+++ b/doc/src/design/https-download-fallback.md
@@ -1,9 +1,0 @@
-# HTTPS download fallback
-
-TGV normally builds a local reference cache by querying the UCSC MariaDB server. Some networks block outbound MariaDB traffic on port 3306 while allowing HTTPS, so the downloader gives the MariaDB connection a five-second acquisition timeout, then falls back to UCSC's HTTPS table dumps when the MariaDB download fails. A MariaDB attempt includes both the connection and table transfer; a failure at either stage starts the HTTPS fallback.
-
-The HTTPS backend imports `chromInfo`, `chromAlias`, `cytoBandIdeo`, and the first available preferred gene table. UCSC publishes these tables as gzip-compressed, tab-separated dumps. TGV uses explicit SQLite schemas for the small cache contract instead of translating arbitrary MySQL DDL. This keeps SQLite types predictable for downstream readers, but a future change to a UCSC dump schema must be reflected in the corresponding schema definition in the downloader.
-
-Rows are streamed from the HTTP response, decompressed, and inserted incrementally to bound memory use. All table changes share one SQLite transaction, and TGV downloads every sequence file referenced by `chromInfo` before committing it. A failed table or sequence download therefore leaves the previous database state intact. If both backends fail, TGV reports both the MariaDB error and the HTTPS error.
-
-Sequence downloads use HTTPS and stream their response into a unique temporary file in the cache directory. Publishing uses a no-clobber operation, so concurrent TGV processes cannot write the same temporary file or replace a completed download. If another process publishes the destination first, both downloads treat the completed destination as the cache entry. Existing cache files are retained without revalidation.


### PR DESCRIPTION
## Summary

- Add an HTTPS fallback for UCSC metadata and genome downloads when MariaDB is unavailable.
- Update the UCSC MariaDB host.

## Design

See [the HTTPS download fallback design note](https://github.com/zeqianli/tgv/blob/fix/ucsc-download-fallback/doc/src/design/https-download-fallback.md).

## Testing

- Not run (not requested).