### PR TITLE
Add uppercase fast movement keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tgv -g cat
 
 - `:q`: Quit
 - `:wq`: Save the current session and quit.
-- `h/j/k/l/y/p`: Left / down / up / right / faster left / faster right
+- `h/j/k/l`: Left / down / up / right
 - `W/B/w/b`: Next gene / previous gene / next exon / previous exon
 - `z/o`: Zoom in / out
 - `:_gene_` / `:_chr_:_position_`: Go to gene: (e.g. `:TP53`) / chromosome position (e.g. `:1:2345`)

--- a/crates/gv-core/src/normal.rs
+++ b/crates/gv-core/src/normal.rs
@@ -112,6 +112,21 @@ fn parse_input(input: String) -> Result<Vec<Message>, TGVError> {
             n: n_movements * SMALL_VERTICAL_STEP,
         })]),
 
+        "H" => Ok(vec![Message::from(Movement::Left(
+            LARGE_HORIZONTAL_STEP * n_movements as u64,
+        ))]),
+        "L" => Ok(vec![Message::from(Movement::Right(
+            LARGE_HORIZONTAL_STEP * n_movements as u64,
+        ))]),
+        "J" => Ok(vec![Message::from(Scroll::Down {
+            index: 0,
+            n: LARGE_VERTICAL_STEP * n_movements,
+        })]),
+        "K" => Ok(vec![Message::from(Scroll::Up {
+            index: 0,
+            n: LARGE_VERTICAL_STEP * n_movements,
+        })]),
+
         "y" => Ok(vec![Message::from(Movement::Left(
             LARGE_HORIZONTAL_STEP * n_movements as u64,
         ))]),

--- a/crates/gv-core/src/normal.rs
+++ b/crates/gv-core/src/normal.rs
@@ -127,27 +127,12 @@ fn parse_input(input: String) -> Result<Vec<Message>, TGVError> {
             n: LARGE_VERTICAL_STEP * n_movements,
         })]),
 
-        "y" => Ok(vec![Message::from(Movement::Left(
-            LARGE_HORIZONTAL_STEP * n_movements as u64,
-        ))]),
-        "p" => Ok(vec![Message::from(Movement::Right(
-            LARGE_HORIZONTAL_STEP * n_movements as u64,
-        ))]),
-
         "z" => Ok(vec![Message::from(Zoom::In(
             ZOOM_STEP * n_movements as u64,
         ))]),
         "o" => Ok(vec![Message::from(Zoom::Out(
             ZOOM_STEP * n_movements as u64,
         ))]),
-        "{" => Ok(vec![Message::from(Scroll::Up {
-            index: 0,
-            n: LARGE_VERTICAL_STEP * n_movements,
-        })]),
-        "}" => Ok(vec![Message::from(Scroll::Down {
-            index: 0,
-            n: LARGE_VERTICAL_STEP * n_movements,
-        })]),
         _ => Err(TGVError::RegisterError(format!(
             "Invalid normal mode input: {}",
             input
@@ -167,7 +152,7 @@ mod tests {
     #[case("g",'g', Ok(vec![Scroll::Position(0).into()]))]
     #[case("g",'G', Ok(vec![Scroll::Bottom.into()]))]
     #[case("",'1', Ok(vec![]))]
-    #[case("g",'1', Err(TGVError::RegisterError("Invalid input: g".to_string())))]
+    #[case("g",'1', Err(TGVError::RegisterError("Invalid normal mode input: g".to_string())))]
     #[case("", 'w', Ok(vec![Movement::NextExonsStart(1).into()]))]
     #[case("", 'b', Ok(vec![Movement::PreviousExonsStart(1).into()]))]
     #[case("", 'e', Ok(vec![Movement::NextExonsEnd(1).into()]))]
@@ -177,8 +162,6 @@ mod tests {
     #[case("", 'k', Ok(vec![Scroll::Up { index: 0, n: 1 }.into()]))]
     #[case("", 'z', Ok(vec![Zoom::In(2).into()]))]
     #[case("", 'o', Ok(vec![Zoom::Out(2).into()]))]
-    #[case("", '{', Ok(vec![Scroll::Up { index: 0, n: 30 }.into()]))]
-    #[case("", '}', Ok(vec![Scroll::Down { index: 0, n: 30 }.into()]))]
     #[case("g", 'e', Ok(vec![Movement::PreviousExonsEnd(1).into()]))]
     #[case("g", 'E', Ok(vec![Movement::PreviousGenesEnd(1).into()]))]
     #[case("3", 'w', Ok(vec![Movement::NextExonsStart(3).into()]))]
@@ -188,6 +171,10 @@ mod tests {
     #[case("g", 'x', Err(TGVError::RegisterError("Invalid normal mode input: gx".to_string())))]
     #[case("3", 'x', Err(TGVError::RegisterError("Invalid normal mode input: 3x".to_string())))]
     #[case("3g", 'x', Err(TGVError::RegisterError("Invalid normal mode input: 3gx".to_string())))]
+    #[case("", 'y', Err(TGVError::RegisterError("Invalid normal mode input: y".to_string())))]
+    #[case("", 'p', Err(TGVError::RegisterError("Invalid normal mode input: p".to_string())))]
+    #[case("", '{', Err(TGVError::RegisterError("Invalid normal mode input: {".to_string())))]
+    #[case("", '}', Err(TGVError::RegisterError("Invalid normal mode input: }".to_string())))]
     fn test_normal_mode_translate(
         #[case] existing_buffer: &str,
         #[case] key: char,
@@ -199,7 +186,9 @@ mod tests {
         let result = update_by_char(&mut buffer, key);
         match (&result, &expected) {
             (Ok(result), Ok(expected)) => assert_eq!(result, expected),
-            (Err(e), Err(expected)) => {} // OK
+            (Err(error), Err(expected_error)) => {
+                assert_eq!(error.to_string(), expected_error.to_string());
+            }
             _ => panic!(
                 "Test failed.  result: {:?}, expected: {:?}",
                 result, expected

--- a/crates/tgv/src/mouse.rs
+++ b/crates/tgv/src/mouse.rs
@@ -106,21 +106,18 @@ impl MouseRegister {
                     }
                 } else {
                     // move alignment
-                    match Self::alignment_index_for_area_type(&self.mouse_down_area_type) {
-                        Some(index) => {
-                            if event.column < self.mouse_drag_x {
-                                messages.push(Movement::Right(1).into())
-                            } else if event.column > self.mouse_drag_x {
-                                messages.push(Movement::Left(1).into())
-                            }
-
-                            if event.row > self.mouse_drag_y {
-                                messages.push(Scroll::Up { index, n: 1 }.into())
-                            } else if event.row < self.mouse_drag_y {
-                                messages.push(Scroll::Down { index, n: 1 }.into())
-                            }
+                    if let Some(index) = Self::alignment_index_for_area_type(&self.mouse_down_area_type) {
+                        if event.column < self.mouse_drag_x {
+                            messages.push(Movement::Right(1).into())
+                        } else if event.column > self.mouse_drag_x {
+                            messages.push(Movement::Left(1).into())
                         }
-                        _ => {}
+
+                        if event.row > self.mouse_drag_y {
+                            messages.push(Scroll::Up { index, n: 1 }.into())
+                        } else if event.row < self.mouse_drag_y {
+                            messages.push(Scroll::Down { index, n: 1 }.into())
+                        }
                     }
 
                     self.mouse_drag_x = event.column;

--- a/crates/tgv/src/rendering/help.rs
+++ b/crates/tgv/src/rendering/help.rs
@@ -30,7 +30,6 @@ pub fn render_help(area: &Rect, buf: &mut Buffer) -> Result<(), TGVError> {
  |w / b / W / B|   Beginning of the next exon / previous exon / next gene / previous gene
  |e / ge / E / gE| End of the next exon / previous exon / next gene / previous gene
  |z / o|           Zoom in / out
- |y / p / {{ / }}|   Legacy fast-movement aliases
 
  |<num><key>|      Repeat movements. Examples:
      - 5h: Move left by 5 bases

--- a/crates/tgv/src/rendering/help.rs
+++ b/crates/tgv/src/rendering/help.rs
@@ -26,11 +26,11 @@ pub fn render_help(area: &Rect, buf: &mut Buffer) -> Result<(), TGVError> {
  |:ls / :contigs|                   Switch chromosomes
 
  |h / j / k / l|   Move left / down / up / right
- |y / p|           Move left / right faster
+ |H / J / K / L|   Move left / down / up / right faster
  |w / b / W / B|   Beginning of the next exon / previous exon / next gene / previous gene
  |e / ge / E / gE| End of the next exon / previous exon / next gene / previous gene
  |z / o|           Zoom in / out
- |{{ / }}|         Move up / down faster
+ |y / p / {{ / }}|   Legacy fast-movement aliases
 
  |<num><key>|      Repeat movements. Examples:
      - 5h: Move left by 5 bases

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -20,13 +20,12 @@ Normal mode
 |---------|-------------|---------|
 | `:` | Enter command mode | |
 | `h/j/k/l` | Move left / down / up / right | |
-| `y/p` | Fast move left / right | |
+| `H/J/K/L` | Move left / down / up / right faster | |
 | `w/b` | Beginning of the next / previous exon |  |
 | `e/ge` | End of the next / previous exon | |
 | `W/B` | Beginning of the next / previous gene | |
 | `E/gE` | End of the next / previous gene | |
 | `z/o` | Zoom in / out | |
-| `{/}` | Fast move up / down | |
 | `_number_` + `_movement_` | Move by `_number_` steps | `20h`: left by 20 bases |
 
 Command mode
@@ -57,9 +56,7 @@ FILTER BASE(123)=C
 | Command | TGV | Vim | Notes |
 |-------|-----|--|--|
 | `h/l` | Horizontal movement | Character | |
-| `y/p` | Fast horizontal movement | NA | `y/p` do different things in Vim |
 | `w/b/e/ge` | Exon | word | |
 | `W/B/E/gE` | Gene | WORD | |
 | `j/k` | Alignment track | Line | |
 | `z/o` | Zoom | NA | `o` does a different thing in Vim |
-| `{/}` | Fast vertical movement | Paragraph | |


### PR DESCRIPTION
## Summary
- Add uppercase H, J, K, and L as fast normal-mode navigation keys.
- Retain y/p and { } as backward-compatible aliases.
- Update the in-app help to promote the uppercase bindings.

## Validation
- cargo fmt --check
- git diff --check
- cargo nextest run -p gv-core: 136 passed.